### PR TITLE
Validate connection on startup and add tests for connection and resolvers

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -57,6 +57,14 @@ export async function ensureConnection(): Promise<void> {
         );
       }
 
+      if (message.includes('invalid-password')) {
+        throw new Error(
+          'Authentication failed: wrong password. ' +
+          'Check ACTUAL_PASSWORD in your configuration. ' +
+          'You can reset your password in Actual Budget under Settings > Server.',
+        );
+      }
+
       throw error;
     }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4,7 +4,7 @@ import type { ConnectionConfig } from './types.js';
 let initialized = false;
 let initializing: Promise<void> | null = null;
 
-function getConfig(): ConnectionConfig {
+export function getConfig(): ConnectionConfig {
   const serverURL = process.env.ACTUAL_SERVER_URL;
   const password = process.env.ACTUAL_PASSWORD;
   const budgetId = process.env.ACTUAL_BUDGET_ID;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,17 @@ registerAllResources(server);
 const transport = new StdioServerTransport();
 await server.connect(transport);
 
+// Validate connection eagerly on startup so config errors surface immediately
+// instead of silently failing on the first tool call
+try {
+  await ensureConnection();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Startup validation failed: ${message}`);
+  // Don't exit — let the MCP server stay alive so the error reaches the client
+  // on the first tool call via ensureConnection's error propagation
+}
+
 process.on('SIGINT', async () => {
   await shutdown();
   process.exit(0);

--- a/src/utils/__tests__/connection.test.ts
+++ b/src/utils/__tests__/connection.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getConfig } from '../../connection.js';
+
+describe('getConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns config when all required vars are set', () => {
+    process.env.ACTUAL_SERVER_URL = 'http://localhost:5007';
+    process.env.ACTUAL_PASSWORD = 'test123';
+    process.env.ACTUAL_BUDGET_ID = 'abc-123';
+
+    const config = getConfig();
+    expect(config.serverURL).toBe('http://localhost:5007');
+    expect(config.password).toBe('test123');
+    expect(config.budgetId).toBe('abc-123');
+  });
+
+  it('defaults password to empty string when not set', () => {
+    process.env.ACTUAL_SERVER_URL = 'http://localhost:5007';
+    process.env.ACTUAL_BUDGET_ID = 'abc-123';
+    delete process.env.ACTUAL_PASSWORD;
+
+    const config = getConfig();
+    expect(config.password).toBe('');
+  });
+
+  it('includes optional encryption password', () => {
+    process.env.ACTUAL_SERVER_URL = 'http://localhost:5007';
+    process.env.ACTUAL_BUDGET_ID = 'abc-123';
+    process.env.ACTUAL_ENCRYPTION_PASSWORD = 'secret';
+
+    const config = getConfig();
+    expect(config.encryptionPassword).toBe('secret');
+  });
+
+  it('includes optional data dir', () => {
+    process.env.ACTUAL_SERVER_URL = 'http://localhost:5007';
+    process.env.ACTUAL_BUDGET_ID = 'abc-123';
+    process.env.ACTUAL_DATA_DIR = '/custom/path';
+
+    const config = getConfig();
+    expect(config.dataDir).toBe('/custom/path');
+  });
+
+  it('throws when ACTUAL_SERVER_URL is missing', () => {
+    delete process.env.ACTUAL_SERVER_URL;
+    process.env.ACTUAL_BUDGET_ID = 'abc-123';
+
+    expect(() => getConfig()).toThrow('Missing required environment variables: ACTUAL_SERVER_URL');
+  });
+
+  it('throws when ACTUAL_BUDGET_ID is missing', () => {
+    process.env.ACTUAL_SERVER_URL = 'http://localhost:5007';
+    delete process.env.ACTUAL_BUDGET_ID;
+
+    expect(() => getConfig()).toThrow('Missing required environment variables: ACTUAL_BUDGET_ID');
+  });
+
+  it('throws when both required vars are missing', () => {
+    delete process.env.ACTUAL_SERVER_URL;
+    delete process.env.ACTUAL_BUDGET_ID;
+
+    expect(() => getConfig()).toThrow('ACTUAL_SERVER_URL');
+    try {
+      getConfig();
+    } catch (e: any) {
+      expect(e.message).toContain('ACTUAL_BUDGET_ID');
+    }
+  });
+});

--- a/src/utils/__tests__/resolvers.test.ts
+++ b/src/utils/__tests__/resolvers.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  getAccounts: vi.fn(),
+  getCategories: vi.fn(),
+  getCategoryGroups: vi.fn(),
+  getPayees: vi.fn(),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { resolveAccountId, resolveCategoryId, resolveCategoryGroupId, resolvePayeeId } from '../resolvers.js';
+
+describe('resolveAccountId', () => {
+  beforeEach(() => {
+    vi.mocked(api.getAccounts).mockResolvedValue([
+      { id: 'acc-1', name: 'BHD Nómina', closed: false, offbudget: false },
+      { id: 'acc-2', name: 'BHD Mi Pais (Pesos)', closed: false, offbudget: false },
+      { id: 'acc-3', name: 'BHD Mi Pais (Dolares)', closed: false, offbudget: false },
+      { id: 'acc-4', name: 'Closed Account', closed: true, offbudget: false },
+    ] as any);
+  });
+
+  it('resolves by exact ID', async () => {
+    expect(await resolveAccountId('acc-1')).toBe('acc-1');
+  });
+
+  it('resolves by partial name (case-insensitive)', async () => {
+    expect(await resolveAccountId('nómina')).toBe('acc-1');
+  });
+
+  it('throws on no match', async () => {
+    await expect(resolveAccountId('nonexistent')).rejects.toThrow('No account found');
+  });
+
+  it('throws on ambiguous match', async () => {
+    await expect(resolveAccountId('BHD Mi Pais')).rejects.toThrow('Ambiguous account name');
+  });
+
+  it('excludes closed accounts from name matching', async () => {
+    await expect(resolveAccountId('Closed')).rejects.toThrow('No account found');
+  });
+
+  it('lists available accounts in error', async () => {
+    try {
+      await resolveAccountId('xyz');
+    } catch (e: any) {
+      expect(e.message).toContain('BHD Nómina');
+    }
+  });
+});
+
+describe('resolveCategoryId', () => {
+  beforeEach(() => {
+    vi.mocked(api.getCategories).mockResolvedValue([
+      { id: 'cat-1', name: 'Alimentación', group_id: 'grp-1', hidden: false },
+      { id: 'cat-2', name: 'Combustible', group_id: 'grp-1', hidden: false },
+      { id: 'cat-3', name: 'Bono Combustible', group_id: 'grp-2', hidden: false },
+      { id: 'cat-4', name: 'Hidden Cat', group_id: 'grp-1', hidden: true },
+    ] as any);
+  });
+
+  it('resolves by exact ID', async () => {
+    expect(await resolveCategoryId('cat-1')).toBe('cat-1');
+  });
+
+  it('resolves by name', async () => {
+    expect(await resolveCategoryId('Alimentación')).toBe('cat-1');
+  });
+
+  it('throws on ambiguous match', async () => {
+    await expect(resolveCategoryId('Combustible')).rejects.toThrow('Ambiguous category name');
+  });
+
+  it('excludes hidden categories', async () => {
+    await expect(resolveCategoryId('Hidden')).rejects.toThrow('No category found');
+  });
+
+  it('throws on no match', async () => {
+    await expect(resolveCategoryId('nonexistent')).rejects.toThrow('No category found');
+  });
+});
+
+describe('resolveCategoryGroupId', () => {
+  beforeEach(() => {
+    vi.mocked(api.getCategoryGroups).mockResolvedValue([
+      { id: 'grp-1', name: 'Gastos Fijos', is_income: false },
+      { id: 'grp-2', name: 'Gastos Variables', is_income: false },
+      { id: 'grp-3', name: 'Income', is_income: true },
+    ] as any);
+  });
+
+  it('resolves by exact ID', async () => {
+    expect(await resolveCategoryGroupId('grp-1')).toBe('grp-1');
+  });
+
+  it('resolves by partial name', async () => {
+    expect(await resolveCategoryGroupId('Fijos')).toBe('grp-1');
+  });
+
+  it('throws on ambiguous match', async () => {
+    await expect(resolveCategoryGroupId('Gastos')).rejects.toThrow('Ambiguous category group name');
+  });
+
+  it('throws on no match', async () => {
+    await expect(resolveCategoryGroupId('nonexistent')).rejects.toThrow('No category group found');
+  });
+
+  it('lists available groups in error', async () => {
+    try {
+      await resolveCategoryGroupId('xyz');
+    } catch (e: any) {
+      expect(e.message).toContain('Gastos Fijos');
+      expect(e.message).toContain('Income');
+    }
+  });
+});
+
+describe('resolvePayeeId', () => {
+  beforeEach(() => {
+    vi.mocked(api.getPayees).mockResolvedValue([
+      { id: 'pay-1', name: 'Sirena' },
+      { id: 'pay-2', name: 'DGII' },
+      { id: 'pay-3', name: 'Transfer: BHD Nómina' },
+      { id: 'pay-4', name: '' },
+    ] as any);
+  });
+
+  it('resolves by exact ID', async () => {
+    expect(await resolvePayeeId('pay-1')).toBe('pay-1');
+  });
+
+  it('resolves by name', async () => {
+    expect(await resolvePayeeId('Sirena')).toBe('pay-1');
+  });
+
+  it('excludes transfer payees', async () => {
+    await expect(resolvePayeeId('Transfer')).rejects.toThrow('No payee found');
+  });
+
+  it('excludes empty-named payees', async () => {
+    // Empty name payee should not be findable
+    const result = await resolvePayeeId('DGII');
+    expect(result).toBe('pay-2');
+  });
+
+  it('throws on no match', async () => {
+    await expect(resolvePayeeId('nonexistent')).rejects.toThrow('No payee found');
+  });
+
+  it('lists available payees in error', async () => {
+    try {
+      await resolvePayeeId('xyz');
+    } catch (e: any) {
+      expect(e.message).toContain('Sirena');
+      expect(e.message).toContain('DGII');
+      expect(e.message).not.toContain('Transfer');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Addresses #2: validates configuration eagerly on MCP startup so errors surface immediately instead of silently failing on the first tool call.

### Changes
- **Eager validation**: calls `ensureConnection()` right after `server.connect()` — if config is wrong, error reaches stderr immediately
- **Exported `getConfig()`** for testability
- **29 new tests** (58 → 87 total):
  - `connection.test.ts` (7): valid config, missing vars, optional vars, error messages
  - `resolvers.test.ts` (22): all 4 resolvers — exact ID, partial name, ambiguous, not found, exclusions, error messages

### Verification
- [x] Build passes
- [x] 87 tests pass
- [x] `npm audit` 0 vulnerabilities
- [x] CI passes (Node 22 + 23)
- [x] E2E: test with wrong password in .mcp.json → should see clear error
- [x] E2E: test with wrong budget ID → should see clear error