### PR TITLE
Split transactions, currency residual tool, and split sub-amount fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.2.4",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
@@ -64,6 +65,80 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -520,12 +595,72 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
@@ -565,6 +700,17 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -952,6 +1098,40 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1113,6 +1293,32 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1121,6 +1327,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -1199,6 +1434,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -1305,6 +1553,26 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
@@ -1487,10 +1755,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1806,6 +2088,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1909,6 +2208,61 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/google-protobuf": {
       "version": "3.21.4",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
@@ -1925,6 +2279,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1959,6 +2323,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -2046,6 +2417,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2057,6 +2438,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.1.3",
@@ -2093,6 +2544,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2101,6 +2559,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2170,6 +2656,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2177,6 +2679,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -2323,6 +2835,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2339,6 +2858,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2803,6 +3339,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2890,6 +3439,110 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2910,6 +3563,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar-fs": {
@@ -2938,6 +3604,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -3301,6 +3982,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },

--- a/src/tools/__tests__/create-split-transaction.test.ts
+++ b/src/tools/__tests__/create-split-transaction.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  getAccounts: vi.fn().mockResolvedValue([
+    { id: 'acc-1', name: 'Checking', closed: false, offbudget: false },
+  ]),
+  getCategories: vi.fn().mockResolvedValue([
+    { id: 'cat-1', name: 'Groceries', group_id: 'g1', hidden: false },
+    { id: 'cat-2', name: 'Cleaning', group_id: 'g1', hidden: false },
+    { id: 'cat-3', name: 'Electronics', group_id: 'g1', hidden: false },
+  ]),
+  addTransactions: vi.fn().mockResolvedValue('ok'),
+  sync: vi.fn().mockResolvedValue(undefined),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { createSplitTransaction } from '../write/create-split-transaction.js';
+
+describe('createSplitTransaction (#28)', () => {
+  beforeEach(() => {
+    vi.mocked(api.addTransactions).mockClear().mockResolvedValue('ok' as any);
+  });
+
+  it('creates a parent with subtransactions when splits sum to the total', async () => {
+    await createSplitTransaction({
+      account: 'Checking',
+      amount: -150,
+      date: '2026-06-05',
+      payee: 'Warehouse Club',
+      splits: [
+        { category: 'Groceries', amount: -90 },
+        { category: 'Cleaning', amount: -40 },
+        { category: 'Electronics', amount: -20 },
+      ],
+    });
+
+    expect(api.addTransactions).toHaveBeenCalledOnce();
+    const [accountId, txns, opts] = vi.mocked(api.addTransactions).mock.calls[0];
+    expect(accountId).toBe('acc-1');
+    expect(opts).toEqual({ learnCategories: false, runTransfers: false });
+    const parent = (txns as any[])[0];
+    expect(parent.amount).toBe(-15000);
+    expect(parent.payee_name).toBe('Warehouse Club');
+    expect(parent.subtransactions).toEqual([
+      { amount: -9000, category: 'cat-1' },
+      { amount: -4000, category: 'cat-2' },
+      { amount: -2000, category: 'cat-3' },
+    ]);
+  });
+
+  it('rejects when the splits do not sum to the total amount', async () => {
+    await expect(
+      createSplitTransaction({
+        account: 'Checking',
+        amount: -150,
+        splits: [
+          { category: 'Groceries', amount: -90 },
+          { category: 'Cleaning', amount: -40 },
+        ],
+      }),
+    ).rejects.toThrow(/sum/i);
+    expect(api.addTransactions).not.toHaveBeenCalled();
+  });
+
+  it('requires at least two splits', async () => {
+    await expect(
+      createSplitTransaction({
+        account: 'Checking',
+        amount: -90,
+        splits: [{ category: 'Groceries', amount: -90 }],
+      }),
+    ).rejects.toThrow(/at least two|two splits/i);
+  });
+
+  it('carries per-split notes when provided', async () => {
+    await createSplitTransaction({
+      account: 'Checking',
+      amount: -100,
+      splits: [
+        { category: 'Groceries', amount: -60, notes: 'food' },
+        { category: 'Cleaning', amount: -40 },
+      ],
+    });
+    const parent = vi.mocked(api.addTransactions).mock.calls[0][1][0] as any;
+    expect(parent.subtransactions[0]).toEqual({ amount: -6000, category: 'cat-1', notes: 'food' });
+    expect(parent.subtransactions[1]).toEqual({ amount: -4000, category: 'cat-2' });
+  });
+});

--- a/src/tools/__tests__/integration/create-split-transaction.integration.test.ts
+++ b/src/tools/__tests__/integration/create-split-transaction.integration.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+// Real @actual-app/api, only api.sync() neutralized (server-less mode).
+vi.mock('@actual-app/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@actual-app/api')>();
+  return { ...actual, sync: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { initTestEngine, shutdownTestEngine, createFreshBudget, api } from './actual-engine.js';
+import { createSplitTransaction } from '../../write/create-split-transaction.js';
+
+const skip = process.env.SKIP_ACTUAL_INTEGRATION === '1';
+
+describe.skipIf(skip)('create_split_transaction integration (#28)', () => {
+  beforeAll(async () => {
+    await initTestEngine();
+  }, 60_000);
+
+  afterAll(async () => {
+    await shutdownTestEngine();
+  });
+
+  it('creates a real split with correct parent total and sub-transactions', async () => {
+    let acctId = '';
+    let c1 = '';
+    let c2 = '';
+    const budgetId = await createFreshBudget(async () => {
+      acctId = await api.createAccount({ name: 'Checking', type: 'checking' } as any, 0);
+      const g = await api.createCategoryGroup({ name: 'G' } as any);
+      c1 = await api.createCategory({ name: 'Groceries', group_id: g } as any);
+      c2 = await api.createCategory({ name: 'Cleaning', group_id: g } as any);
+    });
+
+    await createSplitTransaction({
+      account: 'Checking',
+      amount: -150,
+      date: '2026-06-05',
+      payee: 'Warehouse Club',
+      splits: [
+        { category: 'Groceries', amount: -90 },
+        { category: 'Cleaning', amount: -60 },
+      ],
+    });
+
+    // Reload to be sure it persisted, then read back.
+    await api.loadBudget(budgetId);
+    const txns = await api.getTransactions(acctId, '2026-06-05', '2026-06-05');
+    const parent = txns.find((t: any) => t.is_parent);
+
+    expect(parent, 'parent split transaction should exist').toBeTruthy();
+    expect((parent as any).amount).toBe(-15000);
+    const subs = (parent as any).subtransactions ?? [];
+    expect(subs).toHaveLength(2);
+
+    const sum = subs.reduce((acc: number, s: any) => acc + s.amount, 0);
+    expect(sum).toBe(-15000);
+
+    const byCat = new Map(subs.map((s: any) => [s.category, s.amount]));
+    expect(byCat.get(c1)).toBe(-9000);
+    expect(byCat.get(c2)).toBe(-6000);
+  }, 60_000);
+});

--- a/src/tools/__tests__/integration/mcp-tools.e2e.test.ts
+++ b/src/tools/__tests__/integration/mcp-tools.e2e.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+// Real engine; only api.sync() neutralized (server-less mode).
+vi.mock('@actual-app/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@actual-app/api')>();
+  return { ...actual, sync: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { initTestEngine, shutdownTestEngine, createFreshBudget, api } from './actual-engine.js';
+import { registerCreateSplitTransaction } from '../../write/create-split-transaction.js';
+import { registerUpdateTransaction } from '../../write/update-transaction.js';
+import { registerReconcileCurrencyResidual } from '../../write/reconcile-currency-residual.js';
+
+const skip = process.env.SKIP_ACTUAL_INTEGRATION === '1';
+
+// Drives the tools through the real MCP registration + protocol path (zod input
+// schemas, tool dispatch, content/error formatting) — the wrapper layer that the
+// per-function tests bypass.
+describe.skipIf(skip)('MCP tool wrapper E2E (#28/#25/#30 through the protocol)', () => {
+  let client: Client;
+
+  async function call(name: string, args: Record<string, unknown>) {
+    return client.callTool({ name, arguments: args }) as Promise<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>;
+  }
+
+  beforeAll(async () => {
+    await initTestEngine();
+
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerCreateSplitTransaction(server);
+    registerUpdateTransaction(server);
+    registerReconcileCurrencyResidual(server);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test-client', version: '0.0.0' });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  }, 60_000);
+
+  afterAll(async () => {
+    await shutdownTestEngine();
+  });
+
+  it('create_split_transaction works through the protocol and persists', async () => {
+    let acctId = '';
+    await createFreshBudget(async () => {
+      acctId = await api.createAccount({ name: 'Checking', type: 'checking' } as any, 0);
+      const g = await api.createCategoryGroup({ name: 'G' } as any);
+      await api.createCategory({ name: 'Groceries', group_id: g } as any);
+      await api.createCategory({ name: 'Cleaning', group_id: g } as any);
+    });
+
+    const res = await call('create_split_transaction', {
+      account: 'Checking',
+      amount: -150,
+      date: '2026-06-05',
+      payee: 'Warehouse Club',
+      splits: [
+        { category: 'Groceries', amount: -90 },
+        { category: 'Cleaning', amount: -60 },
+      ],
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain('Split transaction created');
+
+    const parent = (await api.getTransactions(acctId, '2026-06-05', '2026-06-05')).find((t: any) => t.is_parent);
+    expect((parent as any).amount).toBe(-15000);
+    expect((parent as any).subtransactions).toHaveLength(2);
+  }, 60_000);
+
+  it('returns a tool error (not a throw) when splits do not sum to the total', async () => {
+    await createFreshBudget(async () => {
+      await api.createAccount({ name: 'Checking', type: 'checking' } as any, 0);
+      const g = await api.createCategoryGroup({ name: 'G' } as any);
+      await api.createCategory({ name: 'Groceries', group_id: g } as any);
+      await api.createCategory({ name: 'Cleaning', group_id: g } as any);
+    });
+
+    const res = await call('create_split_transaction', {
+      account: 'Checking',
+      amount: -150,
+      splits: [
+        { category: 'Groceries', amount: -90 },
+        { category: 'Cleaning', amount: -40 },
+      ],
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text.toLowerCase()).toContain('sum');
+  }, 60_000);
+
+  it('rejects invalid input via the zod schema (fewer than two splits)', async () => {
+    await createFreshBudget(async () => {
+      await api.createAccount({ name: 'Checking', type: 'checking' } as any, 0);
+      const g = await api.createCategoryGroup({ name: 'G' } as any);
+      await api.createCategory({ name: 'Groceries', group_id: g } as any);
+    });
+
+    // schema requires splits.min(2); the protocol layer surfaces this as a tool error.
+    const res = await call('create_split_transaction', {
+      account: 'Checking',
+      amount: -90,
+      splits: [{ category: 'Groceries', amount: -90 }],
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text.toLowerCase()).toMatch(/split|array|at least|2/);
+  }, 60_000);
+
+  it('reconcile_currency_residual works through the protocol', async () => {
+    let acctId = '';
+    await createFreshBudget(async () => {
+      acctId = await api.createAccount({ name: 'Card (USD)', type: 'credit' } as any, 0);
+      const g = await api.createCategoryGroup({ name: 'G' } as any);
+      await api.createCategory({ name: 'Cashback', group_id: g } as any);
+      await api.addTransactions(
+        acctId,
+        [{ date: '2026-05-01', amount: -10000, payee_name: 'FX drift' }] as any,
+        { learnCategories: false, runTransfers: false },
+      );
+    });
+
+    const res = await call('reconcile_currency_residual', {
+      account: 'Card (USD)',
+      target_balance: 0,
+      category: 'Cashback',
+      date: '2026-06-05',
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain('Currency residual reconciled');
+    expect(await api.getAccountBalance(acctId)).toBe(0);
+  }, 60_000);
+});

--- a/src/tools/__tests__/integration/real-server-write.smoke.test.ts
+++ b/src/tools/__tests__/integration/real-server-write.smoke.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+/**
+ * WRITE smoke test against a REAL Actual server, exercising the real connection
+ * and the real `api.sync()` push (the paths the local server-less integration
+ * tests stub out).
+ *
+ * This WRITES, so it is heavily gated and must target a DEDICATED throwaway
+ * budget — never your real one. It creates its own uniquely-named account and
+ * deletes it (and its transactions) on teardown.
+ *
+ * Enable with:
+ *   ACTUAL_WRITE_SMOKE=1            # explicit opt-in / acknowledgement
+ *   ACTUAL_SERVER_URL=...           # your server
+ *   ACTUAL_PASSWORD=...
+ *   ACTUAL_BUDGET_ID=<TEST budget>  # a dedicated throwaway budget sync id
+ *   npm test -- real-server-write.smoke
+ */
+
+const enabled =
+  process.env.ACTUAL_WRITE_SMOKE === '1' &&
+  !!process.env.ACTUAL_SERVER_URL &&
+  !!process.env.ACTUAL_BUDGET_ID;
+
+describe.skipIf(!enabled)('real server WRITE smoke (#28/#25/#30, dedicated budget)', () => {
+  let api: typeof import('@actual-app/api');
+  let shutdown: typeof import('../../../connection.js').shutdown;
+  let createSplitTransaction: typeof import('../../write/create-split-transaction.js').createSplitTransaction;
+  let updateTransactionFields: typeof import('../../write/update-transaction.js').updateTransactionFields;
+  let reconcileCurrencyResidual: typeof import('../../write/reconcile-currency-residual.js').reconcileCurrencyResidual;
+
+  const stamp = `smoke-${Date.now()}`;
+  let acctId = '';
+  let groupId = '';
+
+  beforeAll(async () => {
+    const conn = await import('../../../connection.js');
+    shutdown = conn.shutdown;
+    api = await import('@actual-app/api');
+    createSplitTransaction = (await import('../../write/create-split-transaction.js')).createSplitTransaction;
+    updateTransactionFields = (await import('../../write/update-transaction.js')).updateTransactionFields;
+    reconcileCurrencyResidual = (await import('../../write/reconcile-currency-residual.js')).reconcileCurrencyResidual;
+
+    await conn.ensureConnection(); // real connect + download of the TEST budget
+
+    acctId = await api.createAccount({ name: `Z-${stamp}`, type: 'checking' } as any, 0);
+    groupId = await api.createCategoryGroup({ name: `ZG-${stamp}` } as any);
+    await api.createCategory({ name: `ZC1-${stamp}`, group_id: groupId } as any);
+    await api.createCategory({ name: `ZC2-${stamp}`, group_id: groupId } as any);
+    await api.sync();
+  }, 120_000);
+
+  afterAll(async () => {
+    // Clean up everything this test created so the budget is left as it was.
+    try {
+      if (acctId) await api.deleteAccount(acctId);
+      if (groupId) await api.deleteCategoryGroup(groupId);
+      await api.sync();
+    } catch {
+      // best-effort cleanup
+    }
+    if (shutdown) await shutdown();
+  }, 120_000);
+
+  it('create_split_transaction persists through a real sync', async () => {
+    await createSplitTransaction({
+      account: `Z-${stamp}`,
+      amount: -150,
+      date: '2026-06-05',
+      payee: `ZP-${stamp}`,
+      splits: [
+        { category: `ZC1-${stamp}`, amount: -90 },
+        { category: `ZC2-${stamp}`, amount: -60 },
+      ],
+    });
+
+    const parent = (await api.getTransactions(acctId, '2026-06-05', '2026-06-05')).find((t: any) => t.is_parent);
+    expect((parent as any)?.amount).toBe(-15000);
+    expect((parent as any)?.subtransactions).toHaveLength(2);
+  }, 120_000);
+
+  it('update_transaction preserves a split sub amount through a real sync', async () => {
+    const parent = (await api.getTransactions(acctId, '2026-06-05', '2026-06-05')).find((t: any) => t.is_parent);
+    const sub = (parent as any).subtransactions[0];
+    await updateTransactionFields({ transaction_id: sub.id, notes: 'smoke' });
+
+    const after = (await api.getTransactions(acctId, '2026-06-05', '2026-06-05')).find((t: any) => t.is_parent);
+    const target = (after as any).subtransactions.find((s: any) => s.id === sub.id);
+    expect(target.amount).toBe(sub.amount);
+    expect((after as any).amount).toBe(-15000);
+  }, 120_000);
+
+  it('reconcile_currency_residual hits the target through a real sync', async () => {
+    await reconcileCurrencyResidual({
+      account: `Z-${stamp}`,
+      target_balance: 0,
+      category: `ZC1-${stamp}`,
+      date: '2026-06-06',
+    });
+    expect(await api.getAccountBalance(acctId)).toBe(0);
+  }, 120_000);
+});

--- a/src/tools/__tests__/integration/reconcile-currency-residual.integration.test.ts
+++ b/src/tools/__tests__/integration/reconcile-currency-residual.integration.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+vi.mock('@actual-app/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@actual-app/api')>();
+  return { ...actual, sync: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { initTestEngine, shutdownTestEngine, createFreshBudget, api } from './actual-engine.js';
+import { reconcileCurrencyResidual } from '../../write/reconcile-currency-residual.js';
+
+const skip = process.env.SKIP_ACTUAL_INTEGRATION === '1';
+
+describe.skipIf(skip)('reconcile_currency_residual integration (#30)', () => {
+  beforeAll(async () => {
+    await initTestEngine();
+  }, 60_000);
+
+  afterAll(async () => {
+    await shutdownTestEngine();
+  });
+
+  it('books an adjustment in the given category that brings the account to target', async () => {
+    let acctId = '';
+    let cashbackId = '';
+    const budgetId = await createFreshBudget(async () => {
+      acctId = await api.createAccount({ name: 'Card (USD)', type: 'credit' } as any, 0);
+      const g = await api.createCategoryGroup({ name: 'G' } as any);
+      cashbackId = await api.createCategory({ name: 'Cashback', group_id: g } as any);
+      // Accumulated FX residual: account sits at -100.00 while the bank says 0.
+      await api.addTransactions(
+        acctId,
+        [{ date: '2026-05-01', amount: -10000, payee_name: 'FX drift' }] as any,
+        { learnCategories: false, runTransfers: false },
+      );
+    });
+
+    const before = await api.getAccountBalance(acctId);
+    expect(before).toBe(-10000);
+
+    await reconcileCurrencyResidual({
+      account: 'Card (USD)',
+      target_balance: 0,
+      category: 'Cashback',
+      date: '2026-06-05',
+    });
+
+    await api.loadBudget(budgetId);
+    const after = await api.getAccountBalance(acctId);
+    expect(after).toBe(0);
+
+    // The adjustment must be the +100.00 transaction booked under Cashback.
+    const adjustments = await api.getTransactions(acctId, '2026-06-05', '2026-06-05');
+    const adjustment = adjustments.find((t: any) => t.amount === 10000);
+    expect(adjustment, 'adjustment transaction should exist').toBeTruthy();
+    expect((adjustment as any).category).toBe(cashbackId);
+  }, 60_000);
+});

--- a/src/tools/__tests__/integration/update-transaction.integration.test.ts
+++ b/src/tools/__tests__/integration/update-transaction.integration.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+vi.mock('@actual-app/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@actual-app/api')>();
+  return { ...actual, sync: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { initTestEngine, shutdownTestEngine, createFreshBudget, api } from './actual-engine.js';
+import { updateTransactionFields } from '../../write/update-transaction.js';
+
+const skip = process.env.SKIP_ACTUAL_INTEGRATION === '1';
+
+describe.skipIf(skip)('update_transaction integration (#25)', () => {
+  beforeAll(async () => {
+    await initTestEngine();
+  }, 60_000);
+
+  afterAll(async () => {
+    await shutdownTestEngine();
+  });
+
+  it('does not zero a split sub-transaction amount when updating without amount', async () => {
+    let acctId = '';
+    let subId = '';
+    const budgetId = await createFreshBudget(async () => {
+      acctId = await api.createAccount({ name: 'Checking', type: 'checking' } as any, 0);
+      const g = await api.createCategoryGroup({ name: 'G' } as any);
+      const c1 = await api.createCategory({ name: 'C1', group_id: g } as any);
+      const c2 = await api.createCategory({ name: 'C2', group_id: g } as any);
+      await api.addTransactions(
+        acctId,
+        [
+          {
+            date: '2026-06-05',
+            amount: -4000,
+            payee_name: 'Store',
+            subtransactions: [
+              { amount: -1500, category: c1 },
+              { amount: -2500, category: c2 },
+            ],
+          },
+        ] as any,
+        { learnCategories: false, runTransfers: false },
+      );
+    });
+
+    let parent = (await api.getTransactions(acctId, '2026-06-05', '2026-06-05')).find((t: any) => t.is_parent);
+    subId = (parent as any).subtransactions[0].id;
+
+    // Update the sub-transaction with notes only — no amount provided (the #25 trigger).
+    await updateTransactionFields({ transaction_id: subId, notes: 'partial' });
+
+    await api.loadBudget(budgetId);
+    parent = (await api.getTransactions(acctId, '2026-06-05', '2026-06-05')).find((t: any) => t.is_parent);
+    const subs = (parent as any).subtransactions;
+    const target = subs.find((s: any) => s.id === subId);
+
+    // The amount must be preserved (not reset to 0) and the split total must stay intact.
+    expect(target.amount).toBe(-1500);
+    expect(subs.reduce((acc: number, s: any) => acc + s.amount, 0)).toBe(-4000);
+    expect((parent as any).amount).toBe(-4000);
+  }, 60_000);
+});

--- a/src/tools/__tests__/reconcile-currency-residual.test.ts
+++ b/src/tools/__tests__/reconcile-currency-residual.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  getAccounts: vi.fn().mockResolvedValue([
+    { id: 'acc-1', name: 'Card (USD)', closed: false, offbudget: false },
+  ]),
+  getAccountBalance: vi.fn(),
+  getCategories: vi.fn().mockResolvedValue([
+    { id: 'cat-1', name: 'Cashback', group_id: 'g1', hidden: false },
+  ]),
+  getTransactions: vi.fn().mockResolvedValue([]),
+  addTransactions: vi.fn().mockResolvedValue('ok'),
+  updateTransaction: vi.fn().mockResolvedValue({}),
+  sync: vi.fn().mockResolvedValue(undefined),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { reconcileCurrencyResidual } from '../write/reconcile-currency-residual.js';
+
+describe('reconcileCurrencyResidual (#30)', () => {
+  beforeEach(() => {
+    vi.mocked(api.addTransactions).mockClear().mockResolvedValue('ok' as any);
+    vi.mocked(api.getTransactions).mockReset().mockResolvedValue([] as any);
+  });
+
+  it('books an adjustment equal to the delta toward the target balance', async () => {
+    // residual debt of -100.00; bank says 0 -> need +100.00 to reach 0
+    vi.mocked(api.getAccountBalance).mockResolvedValue(-10000);
+
+    await reconcileCurrencyResidual({ account: 'Card (USD)', target_balance: 0, category: 'Cashback' });
+
+    expect(api.addTransactions).toHaveBeenCalledOnce();
+    const [accountId, txns] = vi.mocked(api.addTransactions).mock.calls[0];
+    expect(accountId).toBe('acc-1');
+    const txn = (txns as any[])[0];
+    expect(txn.amount).toBe(10000);
+    expect(txn.category).toBe('cat-1');
+    expect(txn.notes).toBe('FX residual adjustment');
+  });
+
+  it('books a negative adjustment when the balance is above target', async () => {
+    vi.mocked(api.getAccountBalance).mockResolvedValue(5000); // +50.00, target 0 -> -50.00
+    await reconcileCurrencyResidual({ account: 'Card (USD)', target_balance: 0, category: 'Cashback' });
+    const txn = (vi.mocked(api.addTransactions).mock.calls[0][1] as any[])[0];
+    expect(txn.amount).toBe(-5000);
+  });
+
+  it('respects a non-zero target balance', async () => {
+    vi.mocked(api.getAccountBalance).mockResolvedValue(-10000); // -100, target -30 -> +70
+    await reconcileCurrencyResidual({ account: 'Card (USD)', target_balance: -30, category: 'Cashback' });
+    const txn = (vi.mocked(api.addTransactions).mock.calls[0][1] as any[])[0];
+    expect(txn.amount).toBe(7000);
+  });
+
+  it('does nothing when the balance already matches the target', async () => {
+    vi.mocked(api.getAccountBalance).mockResolvedValue(0);
+    const lines = await reconcileCurrencyResidual({ account: 'Card (USD)', target_balance: 0, category: 'Cashback' });
+    expect(api.addTransactions).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toMatch(/no adjustment/i);
+  });
+
+  it('allows a custom adjustment note', async () => {
+    vi.mocked(api.getAccountBalance).mockResolvedValue(-10000);
+    await reconcileCurrencyResidual({ account: 'Card (USD)', category: 'Cashback', notes: 'Q2 FX cleanup' });
+    const txn = (vi.mocked(api.addTransactions).mock.calls[0][1] as any[])[0];
+    expect(txn.notes).toBe('Q2 FX cleanup');
+  });
+});

--- a/src/tools/__tests__/update-transaction.test.ts
+++ b/src/tools/__tests__/update-transaction.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  getCategories: vi.fn().mockResolvedValue([
+    { id: 'cat-1', name: 'Groceries', group_id: 'g1', hidden: false },
+  ]),
+  updateTransaction: vi.fn().mockResolvedValue({}),
+  sync: vi.fn().mockResolvedValue(undefined),
+  runQuery: vi.fn(),
+  q: () => ({ filter: () => ({ select: () => ({}) }) }),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { updateTransactionFields } from '../write/update-transaction.js';
+
+describe('updateTransactionFields (#25 split sub-transaction amount)', () => {
+  beforeEach(() => {
+    vi.mocked(api.updateTransaction).mockClear().mockResolvedValue({} as any);
+    vi.mocked(api.runQuery).mockReset();
+  });
+
+  it('preserves the current amount when updating a split sub-transaction without amount', async () => {
+    vi.mocked(api.runQuery).mockResolvedValue({ data: [{ id: 'sub-1', amount: -1500, is_child: true }] } as any);
+
+    await updateTransactionFields({ transaction_id: 'sub-1', category: 'cat-1' });
+
+    expect(api.updateTransaction).toHaveBeenCalledWith('sub-1', { category: 'cat-1', amount: -1500 });
+  });
+
+  it('does not inject an amount for a normal (non-child) transaction', async () => {
+    vi.mocked(api.runQuery).mockResolvedValue({ data: [{ id: 't-1', amount: -500, is_child: false }] } as any);
+
+    await updateTransactionFields({ transaction_id: 't-1', notes: 'hi' });
+
+    expect(api.updateTransaction).toHaveBeenCalledWith('t-1', { notes: 'hi' });
+  });
+
+  it('uses the provided amount as-is and does not query', async () => {
+    await updateTransactionFields({ transaction_id: 'x', amount: -20 });
+
+    expect(api.runQuery).not.toHaveBeenCalled();
+    expect(api.updateTransaction).toHaveBeenCalledWith('x', { amount: -2000 });
+  });
+
+  it('throws when no fields are provided', async () => {
+    await expect(updateTransactionFields({ transaction_id: 'x' })).rejects.toThrow(/no fields/i);
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,6 +21,8 @@ import { registerBalanceHistory } from './read/balance-history.js';
 
 // Write tools
 import { registerCreateTransaction } from './write/create-transaction.js';
+import { registerCreateSplitTransaction } from './write/create-split-transaction.js';
+import { registerReconcileCurrencyResidual } from './write/reconcile-currency-residual.js';
 import { registerUpdateBudgetAmount } from './write/update-budget-amount.js';
 import { registerRecategorizeTransaction } from './write/recategorize-transaction.js';
 import { registerCreateTransfer } from './write/create-transfer.js';
@@ -60,6 +62,8 @@ export function registerAllTools(server: McpServer): void {
 
   // Write
   registerCreateTransaction(server);
+  registerCreateSplitTransaction(server);
+  registerReconcileCurrencyResidual(server);
   registerUpdateBudgetAmount(server);
   registerRecategorizeTransaction(server);
   registerCreateTransfer(server);

--- a/src/tools/write/create-split-transaction.ts
+++ b/src/tools/write/create-split-transaction.ts
@@ -1,0 +1,156 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import * as api from '@actual-app/api';
+import { ensureConnection } from '../../connection.js';
+import { amountToCents, formatMoney } from '../../utils/money.js';
+import { resolveDate } from '../../utils/dates.js';
+import { resolveAccountId, resolveCategoryId } from '../../utils/resolvers.js';
+
+export interface SplitInput {
+  category: string;
+  amount: number;
+  notes?: string;
+}
+
+export interface CreateSplitTransactionInput {
+  account: string;
+  amount: number;
+  splits: SplitInput[];
+  payee?: string;
+  date?: string;
+  notes?: string;
+  cleared?: boolean;
+}
+
+/**
+ * Create a split transaction: a single parent (the bank-facing total) with N
+ * sub-transactions that distribute it across categories. Mirrors how Actual
+ * models splits natively, preserving 1:1 traceability with the bank statement.
+ *
+ * The sum of `splits[].amount` must equal `amount`. Sub-transactions carry their
+ * own explicit category, so no learned-mapping override applies to them.
+ *
+ * Returns the human-readable confirmation lines.
+ */
+export async function createSplitTransaction(
+  input: CreateSplitTransactionInput,
+): Promise<string[]> {
+  await ensureConnection();
+
+  if (!input.splits || input.splits.length < 2) {
+    throw new Error('A split transaction needs at least two splits.');
+  }
+
+  const totalCents = amountToCents(input.amount);
+  const splitCents = input.splits.map((s) => amountToCents(s.amount));
+  const sumCents = splitCents.reduce((acc, c) => acc + c, 0);
+
+  if (sumCents !== totalCents) {
+    throw new Error(
+      `Split amounts must sum to the total. Total is ${formatMoney(totalCents)} ` +
+        `but the splits sum to ${formatMoney(sumCents)}.`,
+    );
+  }
+
+  const accountId = await resolveAccountId(input.account);
+  const txnDate = resolveDate(input.date);
+
+  const subtransactions = await Promise.all(
+    input.splits.map(async (s, i) => {
+      const sub: Record<string, unknown> = {
+        amount: splitCents[i],
+        category: await resolveCategoryId(s.category),
+      };
+      if (s.notes) sub.notes = s.notes;
+      return sub;
+    }),
+  );
+
+  const parent: Record<string, unknown> = {
+    date: txnDate,
+    amount: totalCents,
+    cleared: input.cleared ?? false,
+    subtransactions,
+  };
+  if (input.payee) parent.payee_name = input.payee;
+  if (input.notes) parent.notes = input.notes;
+
+  await api.addTransactions(accountId, [parent as any], {
+    learnCategories: false,
+    runTransfers: false,
+  });
+
+  await api.sync();
+
+  const accounts = await api.getAccounts();
+  const acct = accounts.find((a) => a.id === accountId);
+
+  const lines = [
+    'Split transaction created:',
+    `  Account:  ${acct?.name || accountId}`,
+    `  Date:     ${txnDate}`,
+    `  Total:    ${formatMoney(totalCents)}`,
+  ];
+  if (input.payee) lines.push(`  Payee:    ${input.payee}`);
+  if (input.notes) lines.push(`  Notes:    ${input.notes}`);
+  lines.push(`  Splits (${input.splits.length}):`);
+  input.splits.forEach((s, i) => {
+    lines.push(
+      `    - ${s.category}: ${formatMoney(splitCents[i])}` +
+        (s.notes ? ` (${s.notes})` : ''),
+    );
+  });
+
+  return lines;
+}
+
+export function registerCreateSplitTransaction(server: McpServer): void {
+  server.tool(
+    'create_split_transaction',
+    'Add a split transaction: one bank-facing total spread across multiple categories. The split amounts must sum to the total.',
+    {
+      account: z.string().describe('Account name or ID'),
+      amount: z
+        .number()
+        .describe(
+          'Total amount (negative for expenses, positive for income). Must equal the sum of the splits.',
+        ),
+      splits: z
+        .array(
+          z.object({
+            category: z.string().describe('Category name or ID'),
+            amount: z
+              .number()
+              .describe('Split amount (same sign as the total). Human amounts, not cents.'),
+            notes: z.string().optional().describe('Notes for this split'),
+          }),
+        )
+        .min(2)
+        .describe('Two or more splits whose amounts sum to the total.'),
+      payee: z.string().optional().describe('Payee name'),
+      date: z
+        .string()
+        .optional()
+        .describe('Transaction date (YYYY-MM-DD or "today", "yesterday"). Defaults to today.'),
+      notes: z.string().optional().describe('Notes for the parent transaction'),
+      cleared: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe('Whether the transaction is cleared'),
+    },
+    { readOnlyHint: false },
+    async (input) => {
+      try {
+        const lines = await createSplitTransaction(input);
+        return { content: [{ type: 'text', text: lines.join('\n') }] };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text', text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/write/reconcile-currency-residual.ts
+++ b/src/tools/write/reconcile-currency-residual.ts
@@ -1,0 +1,99 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import * as api from '@actual-app/api';
+import { ensureConnection } from '../../connection.js';
+import { amountToCents, centsToAmount, formatMoney } from '../../utils/money.js';
+import { resolveAccountId } from '../../utils/resolvers.js';
+import { createTransaction } from './create-transaction.js';
+
+export interface ReconcileResidualInput {
+  account: string;
+  category: string;
+  target_balance?: number;
+  notes?: string;
+  date?: string;
+  payee?: string;
+}
+
+/**
+ * Reconcile a multi-currency residual: when an account tracks foreign-currency
+ * activity in local-currency equivalents, FX-rate drift leaves a residual even
+ * when the bank reports a different (often zero) outstanding balance.
+ *
+ * Computes the delta between the account's current balance and `target_balance`
+ * (what the bank reports, default 0) and books a single adjustment transaction
+ * in `category` to close the gap. Returns the confirmation lines.
+ */
+export async function reconcileCurrencyResidual(input: ReconcileResidualInput): Promise<string[]> {
+  await ensureConnection();
+
+  const accountId = await resolveAccountId(input.account);
+  const currentCents = await api.getAccountBalance(accountId);
+  const targetCents = amountToCents(input.target_balance ?? 0);
+  const deltaCents = targetCents - currentCents;
+
+  const accounts = await api.getAccounts();
+  const acctName = accounts.find((a) => a.id === accountId)?.name || accountId;
+
+  if (deltaCents === 0) {
+    return [
+      `No adjustment needed: ${acctName} already at ${formatMoney(currentCents)}.`,
+    ];
+  }
+
+  const lines = await createTransaction({
+    account: accountId,
+    amount: centsToAmount(deltaCents),
+    category: input.category,
+    notes: input.notes || 'FX residual adjustment',
+    date: input.date,
+    payee: input.payee,
+  });
+
+  return [
+    'Currency residual reconciled:',
+    `  Account:    ${acctName}`,
+    `  Was:        ${formatMoney(currentCents)}`,
+    `  Target:     ${formatMoney(targetCents)}`,
+    `  Adjustment: ${formatMoney(deltaCents)}`,
+    ...lines,
+  ];
+}
+
+export function registerReconcileCurrencyResidual(server: McpServer): void {
+  server.tool(
+    'reconcile_currency_residual',
+    'Book an adjustment transaction to bring a multi-currency account to the balance the bank reports, clearing accumulated FX-rate residual.',
+    {
+      account: z.string().describe('Account name or ID to reconcile'),
+      category: z.string().describe('Category to book the adjustment under (name or ID)'),
+      target_balance: z
+        .number()
+        .optional()
+        .default(0)
+        .describe('Balance the bank reports for this account (human amount). Defaults to 0.'),
+      notes: z
+        .string()
+        .optional()
+        .describe('Note for the adjustment. Defaults to "FX residual adjustment".'),
+      date: z
+        .string()
+        .optional()
+        .describe('Date for the adjustment (YYYY-MM-DD or "today"). Defaults to today.'),
+      payee: z.string().optional().describe('Optional payee for the adjustment'),
+    },
+    { readOnlyHint: false },
+    async (input) => {
+      try {
+        const lines = await reconcileCurrencyResidual(input);
+        return { content: [{ type: 'text', text: lines.join('\n') }] };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text', text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/write/update-transaction.ts
+++ b/src/tools/write/update-transaction.ts
@@ -6,6 +6,86 @@ import { amountToCents, formatMoney } from '../../utils/money.js';
 import { resolveDate } from '../../utils/dates.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
 
+export interface UpdateTransactionInput {
+  transaction_id: string;
+  amount?: number;
+  payee?: string;
+  category?: string;
+  date?: string;
+  notes?: string;
+  cleared?: boolean;
+}
+
+/**
+ * Update fields of an existing transaction. Only the provided fields change.
+ *
+ * #25: updating a split sub-transaction without an explicit `amount` makes the
+ * SDK reset that sub-transaction's amount to 0 (silent corruption of the split
+ * total). To prevent this, when no `amount` is provided we look up the target;
+ * if it is a sub-transaction (`is_child`), we re-send its current amount so it
+ * is preserved. The preserved amount is not reported as a change.
+ *
+ * Returns the human-readable confirmation lines.
+ */
+export async function updateTransactionFields(input: UpdateTransactionInput): Promise<string[]> {
+  await ensureConnection();
+
+  const updates: Record<string, unknown> = {};
+  const changes: string[] = [];
+
+  if (input.amount !== undefined) {
+    updates.amount = amountToCents(input.amount);
+    changes.push(`Amount → ${formatMoney(updates.amount as number)}`);
+  }
+
+  if (input.payee !== undefined) {
+    updates.payee_name = input.payee;
+    changes.push(`Payee → ${input.payee}`);
+  }
+
+  if (input.category !== undefined) {
+    updates.category = await resolveCategoryId(input.category);
+    const categories = await api.getCategories();
+    const cat = categories.find((c) => c.id === updates.category);
+    changes.push(`Category → ${cat?.name || input.category}`);
+  }
+
+  if (input.date !== undefined) {
+    updates.date = resolveDate(input.date);
+    changes.push(`Date → ${updates.date}`);
+  }
+
+  if (input.notes !== undefined) {
+    updates.notes = input.notes;
+    changes.push(`Notes → ${input.notes}`);
+  }
+
+  if (input.cleared !== undefined) {
+    updates.cleared = input.cleared;
+    changes.push(`Cleared → ${input.cleared}`);
+  }
+
+  if (changes.length === 0) {
+    throw new Error('No fields to update. Provide at least one field to change.');
+  }
+
+  // #25: preserve a sub-transaction's amount when the caller did not change it.
+  if (updates.amount === undefined) {
+    const result = await api.runQuery(
+      api.q('transactions').filter({ id: input.transaction_id }).select(['id', 'amount', 'is_child']),
+    );
+    const txn = (result as any)?.data?.[0];
+    if (txn?.is_child) {
+      updates.amount = txn.amount;
+    }
+  }
+
+  await api.updateTransaction(input.transaction_id, updates as any);
+  await api.sync();
+
+  return [`Transaction ${input.transaction_id} updated:`, ...changes.map((c) => `  ${c}`)];
+}
+
 export function registerUpdateTransaction(server: McpServer): void {
   server.tool(
     'update_transaction',
@@ -26,60 +106,9 @@ export function registerUpdateTransaction(server: McpServer): void {
       cleared: z.boolean().optional().describe('Whether the transaction is cleared'),
     },
     { readOnlyHint: false, idempotentHint: true },
-    async ({ transaction_id, amount, payee, category, date, notes, cleared }) => {
+    async (input) => {
       try {
-        await ensureConnection();
-
-        const updates: Record<string, unknown> = {};
-        const changes: string[] = [];
-
-        if (amount !== undefined) {
-          updates.amount = amountToCents(amount);
-          changes.push(`Amount → ${formatMoney(updates.amount as number)}`);
-        }
-
-        if (payee !== undefined) {
-          updates.payee_name = payee;
-          changes.push(`Payee → ${payee}`);
-        }
-
-        if (category !== undefined) {
-          updates.category = await resolveCategoryId(category);
-          const categories = await api.getCategories();
-          const cat = categories.find((c) => c.id === updates.category);
-          changes.push(`Category → ${cat?.name || category}`);
-        }
-
-        if (date !== undefined) {
-          updates.date = resolveDate(date);
-          changes.push(`Date → ${updates.date}`);
-        }
-
-        if (notes !== undefined) {
-          updates.notes = notes;
-          changes.push(`Notes → ${notes}`);
-        }
-
-        if (cleared !== undefined) {
-          updates.cleared = cleared;
-          changes.push(`Cleared → ${cleared}`);
-        }
-
-        if (changes.length === 0) {
-          return {
-            content: [{ type: 'text', text: 'No fields to update. Provide at least one field to change.' }],
-            isError: true,
-          };
-        }
-
-        await api.updateTransaction(transaction_id, updates as any);
-        await api.sync();
-
-        const lines = [
-          `Transaction ${transaction_id} updated:`,
-          ...changes.map((c) => `  ${c}`),
-        ];
-
+        const lines = await updateTransactionFields(input);
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Feature sprint adding native split support and a multi-currency reconciliation tool, plus a split data-corruption fix. Each item ships with unit tests and integration tests that run the real local Actual engine.

### Added
- **#28 — `create_split_transaction`**: records one bank-facing parent with N sub-transactions across categories (preserves 1:1 traceability with the bank statement). Validates at least two splits and that split amounts sum to the total (compared as integer cents). Sub-transactions are supported natively by the SDK.
- **#30 — `reconcile_currency_residual`**: books a single adjustment to bring a multi-currency account to the balance the bank reports, clearing accumulated FX-rate residual. Computes the delta to `target_balance` and reuses `create_transaction` so the explicit category is enforced; no-op when already on target.

### Fixed
- **#25 — split sub-transaction amount reset to 0**: updating a split sub-transaction without an explicit `amount` made the SDK zero that sub's amount, corrupting the split total. When no amount is provided, the target is looked up and, if it is a sub-transaction (`is_child`), its current amount is re-sent so it is preserved. An integration test confirms the amount is preserved (and reproduces the zeroing without the fix).

### Testing
- 116 tests pass + 2 skipped (opt-in smoke); `tsc` builds clean.
- Logic extracted to exported functions (`createSplitTransaction`, `updateTransactionFields`, `reconcileCurrencyResidual`) for real unit tests.
- Integration tests exercise the live local Actual engine (server-less, no risk to real data): split creation/persistence, sub-amount preservation, and the residual adjustment landing on target in the given category.
- Added `@vitest/coverage-v8` for on-demand coverage reports (no CI gate yet).

### Known limitation (out of scope)
Changing a sub-transaction's *category* via `update_transaction` does not apply on `@actual-app/api` 26.2.x (a separate SDK limitation, distinct from #25's amount issue). Expected to improve when the SDK is bumped (#18).

Closes #28
Closes #25
Closes #30