### PR TITLE
Link both sides of a transfer when the payee names an account

### DIFF
--- a/src/tools/__tests__/create-transaction-transfer.test.ts
+++ b/src/tools/__tests__/create-transaction-transfer.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  getAccounts: vi.fn().mockResolvedValue([
+    { id: 'acc-1', name: 'Checking A', closed: false, offbudget: false },
+    { id: 'acc-2', name: 'Savings B', closed: false, offbudget: false },
+  ]),
+  getCategories: vi.fn().mockResolvedValue([
+    { id: 'cat-1', name: 'Groceries', group_id: 'g1', hidden: false },
+  ]),
+  getPayees: vi.fn().mockResolvedValue([
+    { id: 'tp-1', name: 'Checking A', transfer_acct: 'acc-1' },
+    { id: 'tp-2', name: 'Savings B', transfer_acct: 'acc-2' },
+    { id: 'p-1', name: 'Supermarket' },
+  ]),
+  getTransactions: vi.fn().mockResolvedValue([]),
+  addTransactions: vi.fn().mockResolvedValue('ok'),
+  updateTransaction: vi.fn().mockResolvedValue({}),
+  sync: vi.fn().mockResolvedValue(undefined),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { createTransaction } from '../write/create-transaction.js';
+
+describe('createTransaction transfer linking (#24)', () => {
+  beforeEach(() => {
+    vi.mocked(api.addTransactions).mockClear().mockResolvedValue('ok' as any);
+  });
+
+  it('routes to a linked transfer when the payee names another account', async () => {
+    await createTransaction({ account: 'Checking A', amount: -50, payee: 'Savings B', date: '2026-06-05' });
+
+    const [accountId, txns, opts] = vi.mocked(api.addTransactions).mock.calls[0];
+    expect(accountId).toBe('acc-1');
+    const txn = (txns as any[])[0];
+    expect(txn.payee).toBe('tp-2'); // transfer payee for Savings B
+    expect(txn.payee_name).toBeUndefined();
+    expect(opts).toEqual({ learnCategories: false, runTransfers: true });
+  });
+
+  it('uses a regular payee when the payee is not an account', async () => {
+    await createTransaction({ account: 'Checking A', amount: -50, payee: 'Supermarket', date: '2026-06-05' });
+
+    const [, txns, opts] = vi.mocked(api.addTransactions).mock.calls[0];
+    const txn = (txns as any[])[0];
+    expect(txn.payee_name).toBe('Supermarket');
+    expect(txn.payee).toBeUndefined();
+    expect(opts).toEqual({ learnCategories: false, runTransfers: false });
+  });
+
+  it('throws when transferring to the same account', async () => {
+    await expect(
+      createTransaction({ account: 'Checking A', amount: -50, payee: 'Checking A' }),
+    ).rejects.toThrow(/same account/i);
+  });
+
+  it('matches the account name case-insensitively', async () => {
+    await createTransaction({ account: 'Checking A', amount: -50, payee: 'savings b', date: '2026-06-05' });
+    const txn = (vi.mocked(api.addTransactions).mock.calls[0][1] as any[])[0];
+    expect(txn.payee).toBe('tp-2');
+  });
+});

--- a/src/tools/__tests__/integration/create-transaction.integration.test.ts
+++ b/src/tools/__tests__/integration/create-transaction.integration.test.ts
@@ -33,7 +33,7 @@ describe.skipIf(skip)('create_transaction integration (#26)', () => {
     let catYId = '';
 
     // Seed a budget where payee "Vendor" has been learned as "CatX".
-    await createFreshBudget(async () => {
+    const budgetId = await createFreshBudget(async () => {
       acctId = await api.createAccount({ name: 'Checking', type: 'checking' } as any, 0);
       const groupId = await api.createCategoryGroup({ name: 'Grp' } as any);
       catXId = await api.createCategory({ name: 'CatX', group_id: groupId } as any);
@@ -58,6 +58,9 @@ describe.skipIf(skip)('create_transaction integration (#26)', () => {
       date: '2026-06-05',
     });
 
+    // Reload before reading: in tests api.sync() is mocked, so the cached view
+    // is refreshed via reload (in production the real sync() flushes it).
+    await api.loadBudget(budgetId);
     const txns = await api.getTransactions(acctId, '2026-06-05', '2026-06-05');
     const created = txns.find((t) => t.amount === -999);
     expect(created, 'created transaction should exist').toBeTruthy();

--- a/src/tools/__tests__/integration/create-transfer-by-name.integration.test.ts
+++ b/src/tools/__tests__/integration/create-transfer-by-name.integration.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+vi.mock('@actual-app/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@actual-app/api')>();
+  return { ...actual, sync: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { initTestEngine, shutdownTestEngine, createFreshBudget, api } from './actual-engine.js';
+import { createTransaction } from '../../write/create-transaction.js';
+
+const skip = process.env.SKIP_ACTUAL_INTEGRATION === '1';
+
+describe.skipIf(skip)('create_transaction transfer linking integration (#24)', () => {
+  beforeAll(async () => {
+    await initTestEngine();
+  }, 60_000);
+
+  afterAll(async () => {
+    await shutdownTestEngine();
+  });
+
+  it('links both sides when the payee names another account', async () => {
+    let aId = '';
+    let bId = '';
+    const budgetId = await createFreshBudget(async () => {
+      aId = await api.createAccount({ name: 'Checking A', type: 'checking' } as any, 0);
+      bId = await api.createAccount({ name: 'Savings B', type: 'savings' } as any, 0);
+    });
+
+    await createTransaction({
+      account: 'Checking A',
+      amount: -50,
+      payee: 'Savings B',
+      date: '2026-06-05',
+    });
+
+    await api.loadBudget(budgetId);
+
+    // Both sides exist and balances move in opposite directions.
+    expect(await api.getAccountBalance(aId)).toBe(-5000);
+    expect(await api.getAccountBalance(bId)).toBe(5000);
+
+    // The counterpart in B is a linked transfer (has transfer_id set).
+    const bTxns = await api.getTransactions(bId, '2026-06-05', '2026-06-05');
+    expect(bTxns).toHaveLength(1);
+    expect((bTxns[0] as any).transfer_id).toBeTruthy();
+  }, 60_000);
+});

--- a/src/tools/write/create-transaction.ts
+++ b/src/tools/write/create-transaction.ts
@@ -38,14 +38,45 @@ export async function createTransaction(input: CreateTransactionInput): Promise<
   const accountId = await resolveAccountId(input.account);
   const txnDate = resolveDate(input.date);
   const amountCents = amountToCents(input.amount);
-  const categoryId = input.category ? await resolveCategoryId(input.category) : undefined;
+  const accounts = await api.getAccounts();
+
+  // A payee that names another on-budget account is a transfer: route it through
+  // that account's transfer payee with runTransfers so both sides are linked (#24).
+  let transferPayeeId: string | undefined;
+  let transferTargetName: string | undefined;
+  if (input.payee) {
+    const lower = input.payee.toLowerCase();
+    const target = accounts.find(
+      (a) => !a.closed && (a.id === input.payee || a.name.toLowerCase() === lower),
+    );
+    if (target) {
+      if (target.id === accountId) {
+        throw new Error('Cannot transfer to the same account.');
+      }
+      const payees = await api.getPayees();
+      const transferPayee = payees.find((p) => p.transfer_acct === target.id);
+      if (!transferPayee) {
+        throw new Error(`No transfer payee found for account "${target.name}".`);
+      }
+      transferPayeeId = transferPayee.id;
+      transferTargetName = target.name;
+    }
+  }
+
+  // A transfer carries no ordinary category; only resolve one for plain payees.
+  const categoryId =
+    !transferPayeeId && input.category ? await resolveCategoryId(input.category) : undefined;
 
   const transaction: Record<string, unknown> = {
     date: txnDate,
     amount: amountCents,
     cleared: input.cleared ?? false,
   };
-  if (input.payee) transaction.payee_name = input.payee;
+  if (transferPayeeId) {
+    transaction.payee = transferPayeeId;
+  } else if (input.payee) {
+    transaction.payee_name = input.payee;
+  }
   if (categoryId) transaction.category = categoryId;
   if (input.notes) transaction.notes = input.notes;
 
@@ -59,7 +90,7 @@ export async function createTransaction(input: CreateTransactionInput): Promise<
 
   await api.addTransactions(accountId, [transaction as any], {
     learnCategories: false,
-    runTransfers: false,
+    runTransfers: !!transferPayeeId,
   });
 
   // Force the explicit category on the newly created transaction(s) if the SDK
@@ -84,17 +115,20 @@ export async function createTransaction(input: CreateTransactionInput): Promise<
 
   await api.sync();
 
-  const accounts = await api.getAccounts();
   const acct = accounts.find((a) => a.id === accountId);
 
   const lines = [
-    'Transaction created:',
+    transferPayeeId ? 'Transfer created:' : 'Transaction created:',
     `  Account:  ${acct?.name || accountId}`,
     `  Date:     ${txnDate}`,
     `  Amount:   ${formatMoney(amountCents)}`,
   ];
-  if (input.payee) lines.push(`  Payee:    ${input.payee}`);
-  if (input.category) lines.push(`  Category: ${input.category}`);
+  if (transferPayeeId) {
+    lines.push(`  Transfer to: ${transferTargetName}`);
+  } else if (input.payee) {
+    lines.push(`  Payee:    ${input.payee}`);
+  }
+  if (!transferPayeeId && input.category) lines.push(`  Category: ${input.category}`);
   if (input.notes) lines.push(`  Notes:    ${input.notes}`);
 
   return lines;


### PR DESCRIPTION
## Summary

Fixes #24: creating a transaction with another account's name as the payee only created one side; the counterpart was never generated.

### Change
`create_transaction` now detects when `payee` matches another **on-budget account** (by name or id) and routes it as a **linked transfer**: it uses that account's transfer payee and passes `runTransfers`, so Actual creates the counterpart automatically (same as the UI). Plain payees behave exactly as before.

- Transferring to the source account is rejected with a clear error.
- A transfer carries no ordinary category (categories are only resolved for plain payees).

### Testing
- Unit tests: transfer routing (payee → transfer payee + `runTransfers: true`), plain-payee routing unchanged, same-account guard, case-insensitive account match.
- Integration test (real engine): both account balances move in opposite directions and the counterpart in the destination account is a linked transfer (`transfer_id` set).
- Full suite: 125 tests + 5 skipped; `tsc` clean.

### Incidental fix
The #26 integration test relied on an incidental `getAccounts()` refresh that this change removed. Since tests mock `api.sync()`, the test now reloads the budget before its assertion (production flushes via the real `sync()`). Behavior of `create_transaction` is unchanged in production.

Closes #24