### PR TITLE
Report full account balances in list_accounts (not just as-of-today)

### DIFF
--- a/src/tools/__tests__/integration/list-accounts.integration.test.ts
+++ b/src/tools/__tests__/integration/list-accounts.integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+vi.mock('@actual-app/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@actual-app/api')>();
+  return { ...actual, sync: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { initTestEngine, shutdownTestEngine, createFreshBudget, api } from './actual-engine.js';
+import { getAccountsReport } from '../../read/list-accounts.js';
+import { formatMoney } from '../../../utils/money.js';
+
+const skip = process.env.SKIP_ACTUAL_INTEGRATION === '1';
+
+describe.skipIf(skip)('list_accounts integration (#21 full balance)', () => {
+  beforeAll(async () => {
+    await initTestEngine();
+  }, 60_000);
+
+  afterAll(async () => {
+    await shutdownTestEngine();
+  });
+
+  it('includes future-dated transactions in the reported balance', async () => {
+    let acctId = '';
+    const budgetId = await createFreshBudget(async () => {
+      acctId = await api.createAccount({ name: 'Checking', type: 'checking' } as any, 0);
+      await api.addTransactions(
+        acctId,
+        [
+          { date: '2026-06-05', amount: -1000, payee_name: 'Past' },
+          { date: '2030-01-01', amount: -7000, payee_name: 'Future' },
+        ] as any,
+        { learnCategories: false, runTransfers: false },
+      );
+    });
+    await api.loadBudget(budgetId);
+
+    // Sanity: the SDK's default (no cutoff) drops the future txn (the bug).
+    expect(await api.getAccountBalance(acctId)).toBe(-1000);
+
+    // The report must show the FULL balance (-80.00), not the as-of-today one (-10.00).
+    const text = await getAccountsReport();
+    expect(text).toContain(`Checking: ${formatMoney(-8000)}`);
+    expect(text).not.toContain(`Checking: ${formatMoney(-1000)}`);
+  }, 60_000);
+});

--- a/src/tools/__tests__/list-accounts.test.ts
+++ b/src/tools/__tests__/list-accounts.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  getAccounts: vi.fn(),
+  getAccountBalance: vi.fn(),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { getAccountsReport } from '../read/list-accounts.js';
+
+describe('getAccountsReport (#21 full balance, not as-of-today)', () => {
+  beforeEach(() => {
+    vi.mocked(api.getAccounts).mockResolvedValue([
+      { id: 'a1', name: 'Checking', closed: false, offbudget: false },
+      { id: 'a2', name: 'Wallet', closed: false, offbudget: true },
+    ] as any);
+    vi.mocked(api.getAccountBalance).mockReset().mockResolvedValue(-8000);
+  });
+
+  it('requests a future-inclusive balance so recent/future-dated transactions are not dropped', async () => {
+    await getAccountsReport();
+    // Without a cutoff the SDK sums only transactions dated <= today, excluding
+    // future-dated ones (#21). A far-future cutoff returns the full balance.
+    expect(api.getAccountBalance).toHaveBeenCalledWith('a1', new Date('9999-12-31'));
+    expect(api.getAccountBalance).toHaveBeenCalledWith('a2', new Date('9999-12-31'));
+  });
+
+  it('renders on-budget and off-budget accounts with their balances', async () => {
+    const text = await getAccountsReport();
+    expect(text).toContain('Checking');
+    expect(text).toContain('Wallet');
+    expect(text).toMatch(/On-Budget/i);
+    expect(text).toMatch(/Off-Budget/i);
+  });
+
+  it('excludes closed accounts', async () => {
+    vi.mocked(api.getAccounts).mockResolvedValue([
+      { id: 'a1', name: 'Open', closed: false, offbudget: false },
+      { id: 'a3', name: 'Gone', closed: true, offbudget: false },
+    ] as any);
+    const text = await getAccountsReport();
+    expect(text).toContain('Open');
+    expect(text).not.toContain('Gone');
+  });
+});

--- a/src/tools/read/list-accounts.ts
+++ b/src/tools/read/list-accounts.ts
@@ -4,6 +4,53 @@ import { ensureConnection } from '../../connection.js';
 import { formatMoney } from '../../utils/money.js';
 import { sectionHeader } from '../../utils/formatters.js';
 
+// api.getAccountBalance sums only transactions dated on or before the cutoff,
+// defaulting to "today" when no cutoff is given — which silently drops
+// future-dated transactions from the reported balance (#21). A far-future
+// cutoff yields the full account balance, matching what Actual shows.
+const FULL_BALANCE_CUTOFF = new Date('9999-12-31');
+
+/**
+ * Build the accounts report (names, balances, on/off-budget grouping). Returns
+ * the formatted text.
+ */
+export async function getAccountsReport(): Promise<string> {
+  await ensureConnection();
+  const accounts = await api.getAccounts();
+
+  const onBudget = accounts.filter((a) => !a.closed && !a.offbudget);
+  const offBudget = accounts.filter((a) => !a.closed && a.offbudget);
+
+  const lines: string[] = [sectionHeader('Accounts'), ''];
+
+  let totalOnBudget = 0;
+  if (onBudget.length > 0) {
+    lines.push('On-Budget:');
+    for (const account of onBudget) {
+      const balance = await api.getAccountBalance(account.id, FULL_BALANCE_CUTOFF);
+      totalOnBudget += balance;
+      lines.push(`  ${account.name}: ${formatMoney(balance)}`);
+    }
+    lines.push('');
+  }
+
+  let totalOffBudget = 0;
+  if (offBudget.length > 0) {
+    lines.push('Off-Budget:');
+    for (const account of offBudget) {
+      const balance = await api.getAccountBalance(account.id, FULL_BALANCE_CUTOFF);
+      totalOffBudget += balance;
+      lines.push(`  ${account.name}: ${formatMoney(balance)}`);
+    }
+    lines.push('');
+  }
+
+  lines.push(`Total on-budget: ${formatMoney(totalOnBudget)}`);
+  lines.push(`Total off-budget: ${formatMoney(totalOffBudget)}`);
+
+  return lines.join('\n');
+}
+
 export function registerListAccounts(server: McpServer): void {
   server.tool(
     'list_accounts',
@@ -12,40 +59,8 @@ export function registerListAccounts(server: McpServer): void {
     { readOnlyHint: true },
     async () => {
       try {
-        await ensureConnection();
-        const accounts = await api.getAccounts();
-
-        const onBudget = accounts.filter((a) => !a.closed && !a.offbudget);
-        const offBudget = accounts.filter((a) => !a.closed && a.offbudget);
-
-        const lines: string[] = [sectionHeader('Accounts'), ''];
-
-        let totalOnBudget = 0;
-        if (onBudget.length > 0) {
-          lines.push('On-Budget:');
-          for (const account of onBudget) {
-            const balance = await api.getAccountBalance(account.id);
-            totalOnBudget += balance;
-            lines.push(`  ${account.name}: ${formatMoney(balance)}`);
-          }
-          lines.push('');
-        }
-
-        let totalOffBudget = 0;
-        if (offBudget.length > 0) {
-          lines.push('Off-Budget:');
-          for (const account of offBudget) {
-            const balance = await api.getAccountBalance(account.id);
-            totalOffBudget += balance;
-            lines.push(`  ${account.name}: ${formatMoney(balance)}`);
-          }
-          lines.push('');
-        }
-
-        lines.push(`Total on-budget: ${formatMoney(totalOnBudget)}`);
-        lines.push(`Total off-budget: ${formatMoney(totalOffBudget)}`);
-
-        return { content: [{ type: 'text', text: lines.join('\n') }] };
+        const text = await getAccountsReport();
+        return { content: [{ type: 'text', text }] };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {


### PR DESCRIPTION
## Summary

Fixes #21: `list_accounts` balances looked stale/wrong — they did not reflect some recently created transactions, even though `get_transactions` showed them.

### Root cause
`api.getAccountBalance(id, cutoff)` sums only transactions dated **on or before `cutoff`**, and `cutoff` defaults to **today** when omitted. `list_accounts` called it with no cutoff, so the reported balance silently excluded **future-dated** transactions (verified against the SDK: `SELECT sum(amount) ... WHERE date <= dayFromDate(cutoff)`).

### Fix
`list_accounts` now passes a far-future cutoff, so the reported balance includes all transactions — matching what Actual shows. Logic extracted to an exported `getAccountsReport()` for unit testing.

### Testing
- Unit: asserts the far-future cutoff is used; on/off-budget grouping; closed accounts excluded.
- Integration (real engine): a future-dated transaction **is** included in the reported balance, and a sanity assertion confirms the SDK default drops it (reproducing the bug).
- Full suite: 124 tests + 5 skipped; `tsc` clean.

Closes #21