### PR TITLE
Read the MCP server version from package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,14 @@ import { registerAllPrompts } from './prompts.js';
 import { registerAllResources } from './resources.js';
 import { ensureConnection, shutdown } from './connection.js';
 import * as api from '@actual-app/api';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Read the version from package.json at runtime so it never drifts from the
+// published version. Resolves to the package root in both dev and the npm build.
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8'),
+) as { version: string };
 
 // Redirect console.log/warn/info to stderr so they don't contaminate
 // the MCP JSON-RPC protocol on stdout. Libraries like @actual-app/api
@@ -46,7 +54,7 @@ if (process.argv.includes('--verify')) {
 
 const server = new McpServer({
   name: 'actual-budget-mcp',
-  version: '0.4.2',
+  version: pkg.version,
 });
 
 registerAllTools(server);


### PR DESCRIPTION
## Summary

The MCP server version was hard-coded in `src/index.ts` (`version: '0.4.2'`) and never updated on version bumps, so the server advertised a stale version over the MCP handshake even while running newer code (e.g. it reported 0.4.2 while running 0.6.0).

Now it reads the version from `package.json` at runtime (via `import.meta.url`), so the advertised version always matches the published one and cannot drift again.

## Testing
- `tsc` builds clean; full suite (129 + 5 skipped) passes.
- Verified the runtime read resolves to the current `package.json` version.