### PR TITLE
Survive sync failures, and add the account/repair tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 *.tgz
 actual-data/
 backlog.md
+
+# Local-only notes (never commit)
+*.local.md

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ This will connect to your Actual Budget server and confirm everything is configu
 3. Click **Show advanced settings**
 4. Copy the **Sync ID**
 
-## Tools (32)
+## Tools (37)
 
 ### Read (9)
 
@@ -203,16 +203,18 @@ This will connect to your Actual Budget server and confirm everything is configu
 
 </details>
 
-### Write — Transactions (7)
+### Write — Transactions (9)
 
 | Tool | Description | Example prompt |
 |------|-------------|----------------|
 | `create_transaction` | Add a new transaction | "I spent 500 on groceries from Cartera today" |
+| `create_split_transaction` | One charge across several categories | "Split that 3,000 charge: 2,000 groceries, 1,000 household" |
 | `update_transaction` | Edit an existing transaction | "Change the amount on that transaction to 600" |
 | `delete_transaction` | Remove a transaction | "Delete that test transaction" |
 | `update_budget_amount` | Change a budget amount | "Set my food budget to 15,000 for this month" |
 | `recategorize_transaction` | Move to another category | "Move that transaction to Entertainment" |
 | `create_transfer` | Transfer between accounts | "Transfer 10,000 from Checking to Savings" |
+| `reconcile_currency_residual` | Clear accumulated FX-rate residual | "Reconcile my USD card to 213.82 USD" |
 | `run_bank_sync` | Sync with linked banks | "Sync my bank transactions" |
 
 <details>
@@ -229,6 +231,10 @@ This will connect to your Actual Budget server and confirm everything is configu
 **recategorize_transaction** - `transaction_id` (required) | `category` (required)
 
 **create_transfer** - `from_account` (required) | `to_account` (required) | `amount` (required) | `date` (optional) | `notes` (optional)
+
+**create_split_transaction** - `account` (required) | `amount` (required): total, must equal the sum of the splits | `splits` (required): two or more `{category, amount, notes}` | `payee`, `date`, `notes`, `cleared` (all optional)
+
+**reconcile_currency_residual** - `account` (required) | `category` (required): where to book the adjustment | `target_balance` (optional, defaults to 0) | `payee`, `date`, `notes` (all optional)
 
 **run_bank_sync** - `account` (optional): sync specific account or all if omitted
 
@@ -284,6 +290,48 @@ This will connect to your Actual Budget server and confirm everything is configu
 **create_rule** - `condition_field` (required): payee, category, amount, notes | `condition_op` (required): is, contains, oneOf, gt, lt, etc. | `condition_value` (required) | `action_field` (required): category, payee, notes | `action_value` (required) | `stage` (optional)
 
 **delete_rule** - `rule_id` (required)
+
+</details>
+
+### Write — Accounts (2)
+
+| Tool | Description | Example prompt |
+|------|-------------|----------------|
+| `create_account` | Create an on- or off-budget account | "Create an off-budget account called Family Investment with 10,000" |
+| `delete_account` | Delete an account and its history | "Delete the ZZ Test account" |
+
+> **`delete_account` needs two keys.** It destroys the account's entire transaction
+> history, so a single call never deletes. The first call only *previews* what
+> would be lost (name, balance, transaction count) and suggests closing the
+> account instead — closing retires it while keeping its history. To actually
+> delete, call again with `confirm: true` **and** `confirm_name` set to the
+> account's exact name. While it declines, the tool reports `isError: true`, so a
+> confirmation prompt is never mistaken for a completed deletion.
+
+<details>
+<summary>Parameters</summary>
+
+**create_account** - `name` (required) | `offBudget` (optional, default false) | `initialBalance` (optional): human amount, creates the "Starting Balance" transaction. (Actual models accounts as on/off-budget only, so there is no account `type`.)
+
+**delete_account** - `account` (required): name or ID | `confirm` (required to delete): must be `true` | `confirm_name` (required to delete): the account's exact name
+
+</details>
+
+### Maintenance (1)
+
+| Tool | Description | Example prompt |
+|------|-------------|----------------|
+| `repair_sync` | Repair an out-of-sync budget | "Repair the sync, everything is failing" |
+
+> If tools start failing with a sync error, the budget's sync state is
+> inconsistent with the server. `repair_sync` rebuilds that state without
+> touching budget data. Note that deleting the local `ACTUAL_DATA_DIR` does
+> *not* fix this — the inconsistency is in the sync state, not the cache.
+
+<details>
+<summary>Parameters</summary>
+
+**repair_sync** - no parameters
 
 </details>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@actual-app/core/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1320,12 +1320,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {
@@ -1447,9 +1447,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1878,9 +1878,9 @@
       "license": "MIT"
     },
     "node_modules/csv-stringify": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
-      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.3.tgz",
+      "integrity": "sha512-gIeSCvq5F4VtXV3naV3VAewLhBkiZBz+PPhTOA8H3Y8h/ELa+R1ml0GZck/4/Nzo9ep2lvOluilJ6MJlbZsKMA==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -2314,9 +2314,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -2628,9 +2628,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "chevrotain": "^6.5.0",
@@ -2731,9 +2731,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3213,9 +3213,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -3772,9 +3772,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -4200,9 +4200,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -4382,9 +4382,9 @@
       "license": "MIT"
     },
     "node_modules/typescript-strict-plugin/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4492,9 +4492,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -4867,9 +4867,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "vitest": "^3.0.0"
   },
   "overrides": {
-    "fast-uri": "^3.1.2"
+    "adm-zip": "^0.6.0",
+    "hono": "^4.13.3",
+    "ip-address": "^10.5.0",
+    "fast-uri": "^3.1.5"
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4,6 +4,23 @@ import type { ConnectionConfig } from './types.js';
 let initialized = false;
 let initializing: Promise<void> | null = null;
 
+/**
+ * The context `api.init()` returns. Its `send` reaches Actual's internal
+ * handlers, which is the only way to run maintenance operations the public API
+ * does not wrap — notably `sync-repair` (#41).
+ */
+type ActualInternal = Awaited<ReturnType<typeof api.init>>;
+let internal: ActualInternal | null = null;
+
+export function getInternal(): ActualInternal {
+  if (!internal) {
+    throw new Error(
+      'Not connected to Actual Budget yet. This operation needs an active connection.',
+    );
+  }
+  return internal;
+}
+
 export function getConfig(): ConnectionConfig {
   const serverURL = process.env.ACTUAL_SERVER_URL;
   const password = process.env.ACTUAL_PASSWORD;
@@ -39,7 +56,7 @@ export async function ensureConnection(): Promise<void> {
     const config = getConfig();
 
     try {
-      await api.init({
+      internal = await api.init({
         dataDir: config.dataDir || '/tmp/actual-budget-mcp-data',
         serverURL: config.serverURL,
         password: config.password,
@@ -130,6 +147,7 @@ export async function shutdown(): Promise<void> {
   await api.shutdown();
   initialized = false;
   initializing = null;
+  internal = null;
 }
 
 export { api };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { registerAllTools } from './tools/index.js';
 import { registerAllPrompts } from './prompts.js';
 import { registerAllResources } from './resources.js';
 import { ensureConnection, shutdown } from './connection.js';
+import { installProcessGuards } from './utils/process-guards.js';
+import { describeError } from './utils/errors.js';
 import * as api from '@actual-app/api';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -28,6 +30,13 @@ console.log = (...args: unknown[]) => console.error(...args);
 console.info = (...args: unknown[]) => console.error(...args);
 console.warn = (...args: unknown[]) => console.error(...args);
 
+// #39: keep a rejection from inside @actual-app/api (e.g. a failed budget
+// download) from killing the process under Node's default
+// --unhandled-rejections=throw (the default since Node 15). Installed before
+// anything that can reject — including --verify, which awaits the very call
+// whose stray rejections motivated this.
+installProcessGuards();
+
 // --verify flag: test connection and exit (restore stdout for user output)
 if (process.argv.includes('--verify')) {
   console.log = originalLog;
@@ -46,8 +55,7 @@ if (process.argv.includes('--verify')) {
     await shutdown();
     process.exit(0);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`Connection failed: ${message}`);
+    console.error(`Connection failed: ${describeError(error)}`);
     process.exit(1);
   }
 }
@@ -69,8 +77,7 @@ await server.connect(transport);
 try {
   await ensureConnection();
 } catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`Startup validation failed: ${message}`);
+  console.error(`Startup validation failed: ${describeError(error)}`);
   // Don't exit — let the MCP server stay alive so the error reaches the client
   // on the first tool call via ensureConnection's error propagation
 }

--- a/src/test-connection.ts
+++ b/src/test-connection.ts
@@ -3,6 +3,7 @@
 import 'dotenv/config';
 import * as api from '@actual-app/api';
 import { formatMoney } from './utils/money.js';
+import { describeError } from './utils/errors.js';
 
 async function testConnection() {
   const { ACTUAL_SERVER_URL, ACTUAL_PASSWORD, ACTUAL_BUDGET_ID, ACTUAL_ENCRYPTION_PASSWORD, ACTUAL_DATA_DIR } = process.env;
@@ -95,8 +96,11 @@ async function testConnection() {
 
     await api.shutdown();
   } catch (error) {
+    // #40: keep the raw message for the classification below, but report the
+    // described one — this diagnostic is what a user runs when the server is
+    // broken, and the most common failure throws an empty Error.
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`\nError: ${message}`);
+    console.error(`\nError: ${describeError(error)}`);
 
     if (message.includes('fetch') || message.includes('ECONNREFUSED')) {
       console.error('\nCould not connect to the server. Check that:');

--- a/src/tools/__tests__/create-account.test.ts
+++ b/src/tools/__tests__/create-account.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  createAccount: vi.fn(),
+  sync: vi.fn().mockResolvedValue(undefined),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { createNewAccount } from '../write/create-account.js';
+
+describe('createNewAccount (#38)', () => {
+  beforeEach(() => {
+    vi.mocked(api.createAccount).mockReset().mockResolvedValue('acct-new');
+    vi.mocked(api.sync).mockClear().mockResolvedValue(undefined);
+  });
+
+  it('creates an on-budget account by default', async () => {
+    await createNewAccount({ name: 'Savings' });
+
+    expect(api.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Savings', offbudget: false }),
+      0,
+    );
+  });
+
+  it('creates an off-budget account when asked', async () => {
+    await createNewAccount({ name: 'Family Investment', offBudget: true });
+
+    expect(api.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Family Investment', offbudget: true }),
+      0,
+    );
+  });
+
+  it('converts the initial balance to cents', async () => {
+    await createNewAccount({ name: 'Wallet', initialBalance: 150.5 });
+
+    expect(api.createAccount).toHaveBeenCalledWith(expect.anything(), 15050);
+  });
+
+  it('returns the new account id so transactions can target it', async () => {
+    const lines = await createNewAccount({ name: 'Savings' });
+
+    expect(lines.join('\n')).toContain('acct-new');
+  });
+
+  it('rejects an empty name', async () => {
+    await expect(createNewAccount({ name: '   ' })).rejects.toThrow(/name/i);
+    expect(api.createAccount).not.toHaveBeenCalled();
+  });
+
+  it('never forwards a field Actual does not model, even if a caller sends one', async () => {
+    // Actual models accounts as on/off-budget only — APIAccountEntity has no
+    // `type`. Forwarding one is silently dropped by the API, so accepting it
+    // would report a change that never happened.
+    await createNewAccount({ name: 'Savings', type: 'savings' } as any);
+
+    const account = vi.mocked(api.createAccount).mock.calls[0][0];
+    expect(account).not.toHaveProperty('type');
+  });
+
+  it('does not claim a type in its output', async () => {
+    const lines = await createNewAccount({ name: 'Savings', type: 'savings' } as any);
+
+    expect(lines.join('\n')).not.toMatch(/type/i);
+  });
+});

--- a/src/tools/__tests__/delete-account.test.ts
+++ b/src/tools/__tests__/delete-account.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  getAccounts: vi.fn(),
+  getAccountBalance: vi.fn(),
+  getTransactions: vi.fn(),
+  deleteAccount: vi.fn(),
+  sync: vi.fn().mockResolvedValue(undefined),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as api from '@actual-app/api';
+import { deleteAccountGuarded } from '../write/delete-account.js';
+
+describe('deleteAccountGuarded (destructive: needs explicit confirmation)', () => {
+  beforeEach(() => {
+    vi.mocked(api.getAccounts).mockReset().mockResolvedValue([
+      { id: 'a1', name: 'Old Savings', closed: false, offbudget: false },
+    ] as any);
+    vi.mocked(api.getAccountBalance).mockReset().mockResolvedValue(-2500);
+    vi.mocked(api.getTransactions).mockReset().mockResolvedValue([
+      { id: 't1' },
+      { id: 't2' },
+      { id: 't3' },
+    ] as any);
+    vi.mocked(api.deleteAccount).mockReset().mockResolvedValue(undefined);
+    vi.mocked(api.sync).mockClear().mockResolvedValue(undefined);
+  });
+
+  it('does not delete on the first call, it previews instead', async () => {
+    const result = await deleteAccountGuarded({ account: 'Old Savings' });
+
+    expect(result.deleted).toBe(false);
+    expect(api.deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('shows what would be lost: name, balance and transaction count', async () => {
+    const result = await deleteAccountGuarded({ account: 'Old Savings' });
+    const text = result.lines.join('\n');
+
+    expect(text).toContain('Old Savings');
+    expect(text).toContain('3');
+    expect(text).toMatch(/25\.00/);
+  });
+
+  it('suggests closing the account as the non-destructive alternative', async () => {
+    const result = await deleteAccountGuarded({ account: 'Old Savings' });
+
+    expect(result.lines.join('\n')).toMatch(/clos/i);
+  });
+
+  it('warns about the side effects Actual cannot undo', async () => {
+    // Deleting also unlinks bank sync (not undoable in Actual) and strips the
+    // payee/transfer_id from the matching leg in other accounts.
+    const text = (await deleteAccountGuarded({ account: 'Old Savings' })).lines.join('\n');
+
+    expect(text).toMatch(/bank sync|unlink/i);
+    expect(text).toMatch(/transfer/i);
+  });
+
+  it('still refuses with confirm alone, requiring the exact name', async () => {
+    const result = await deleteAccountGuarded({ account: 'Old Savings', confirm: true });
+
+    expect(result.deleted).toBe(false);
+    expect(api.deleteAccount).not.toHaveBeenCalled();
+    expect(result.lines.join('\n')).toMatch(/confirm_name/i);
+  });
+
+  it('refuses when the typed name does not match exactly', async () => {
+    await expect(
+      deleteAccountGuarded({ account: 'Old Savings', confirm: true, confirm_name: 'old savings' }),
+    ).rejects.toThrow(/does not match/i);
+
+    expect(api.deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('deletes only with confirm plus the exact name', async () => {
+    const result = await deleteAccountGuarded({
+      account: 'Old Savings',
+      confirm: true,
+      confirm_name: 'Old Savings',
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(api.deleteAccount).toHaveBeenCalledWith('a1');
+    expect(api.sync).toHaveBeenCalled();
+  });
+
+  it('reports an unknown account clearly', async () => {
+    await expect(deleteAccountGuarded({ account: 'Nope' })).rejects.toThrow(/no account/i);
+  });
+
+  // api.deleteAccount early-returns for an already-closed account, so claiming
+  // success would be a lie — and it unlinks bank sync before that return, which
+  // Actual cannot undo.
+  it('refuses a closed account instead of reporting a delete that never happens', async () => {
+    vi.mocked(api.getAccounts).mockResolvedValue([
+      { id: 'closed-1', name: 'Retired Card', closed: true, offbudget: false },
+    ] as any);
+
+    await expect(
+      deleteAccountGuarded({
+        account: 'closed-1',
+        confirm: true,
+        confirm_name: 'Retired Card',
+      }),
+    ).rejects.toThrow(/closed/i);
+
+    expect(api.deleteAccount).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/__tests__/list-accounts.test.ts
+++ b/src/tools/__tests__/list-accounts.test.ts
@@ -15,7 +15,19 @@ vi.mock('../../connection.js', () => ({
 }));
 
 import * as api from '@actual-app/api';
-import { getAccountsReport } from '../read/list-accounts.js';
+import { getAccountsReport, registerListAccounts } from '../read/list-accounts.js';
+
+/** Capture the handler a tool registers so the catch block can be exercised. */
+function captureHandler(register: (server: any) => void): (args: any) => Promise<any> {
+  let handler: ((args: any) => Promise<any>) | undefined;
+  register({
+    tool: (...args: unknown[]) => {
+      handler = args[args.length - 1] as (args: any) => Promise<any>;
+    },
+  });
+  if (!handler) throw new Error('tool did not register a handler');
+  return handler;
+}
 
 describe('getAccountsReport (#21 full balance, not as-of-today)', () => {
   beforeEach(() => {
@@ -50,5 +62,27 @@ describe('getAccountsReport (#21 full balance, not as-of-today)', () => {
     const text = await getAccountsReport();
     expect(text).toContain('Open');
     expect(text).not.toContain('Gone');
+  });
+});
+
+describe('list_accounts error reporting (#40)', () => {
+  it('does not report a bare "Error:" when the API throws an empty error', async () => {
+    vi.mocked(api.getAccounts).mockRejectedValue(new Error(''));
+    const handler = captureHandler(registerListAccounts);
+
+    const result = await handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.trim()).not.toBe('Error:');
+    expect(result.content[0].text).toMatch(/log|stderr/i);
+  });
+
+  it('explains how to recover when the budget is out-of-sync', async () => {
+    vi.mocked(api.getAccounts).mockRejectedValue(new Error('SyncError: out-of-sync'));
+    const handler = captureHandler(registerListAccounts);
+
+    const result = await handler({});
+
+    expect(result.content[0].text).toMatch(/repair/i);
   });
 });

--- a/src/tools/__tests__/repair-sync.test.ts
+++ b/src/tools/__tests__/repair-sync.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  default: {},
+  sync: vi.fn().mockResolvedValue(undefined),
+  utils: {
+    amountToInteger: (amount: number) => Math.round(amount * 100),
+    integerToAmount: (cents: number) => cents / 100,
+  },
+}));
+
+const send = vi.fn();
+
+vi.mock('../../connection.js', () => ({
+  ensureConnection: vi.fn().mockResolvedValue(undefined),
+  getInternal: () => ({ send }),
+}));
+
+import * as api from '@actual-app/api';
+import { ensureConnection } from '../../connection.js';
+import { repairSyncState } from '../write/repair-sync.js';
+
+describe('repairSyncState (#41 recover from an out-of-sync budget)', () => {
+  beforeEach(() => {
+    send.mockReset().mockResolvedValue(undefined);
+    vi.mocked(api.sync).mockClear().mockResolvedValue(undefined);
+    vi.mocked(ensureConnection).mockReset().mockResolvedValue(undefined);
+  });
+
+  it('still repairs when the connection failed because the budget is out of sync', async () => {
+    // ensureConnection() runs downloadBudget(), which is exactly what throws on
+    // an out-of-sync budget. Bailing out there would make this tool useless in
+    // the only situation it exists for: the budget is already loaded by then,
+    // so the repair must go ahead.
+    vi.mocked(ensureConnection).mockRejectedValue(new Error(''));
+
+    await repairSyncState();
+
+    expect(send).toHaveBeenCalledWith('sync-repair');
+  });
+
+  it("runs Actual's sync-repair handler", async () => {
+    await repairSyncState();
+
+    expect(send).toHaveBeenCalledWith('sync-repair');
+  });
+
+  it('syncs afterwards so the repaired state reaches the server', async () => {
+    await repairSyncState();
+
+    expect(api.sync).toHaveBeenCalled();
+  });
+
+  it('reports success in the returned lines', async () => {
+    const lines = await repairSyncState();
+
+    expect(lines.join('\n')).toMatch(/repair/i);
+  });
+
+  it('surfaces a clear error when the repair itself fails', async () => {
+    send.mockRejectedValue(new Error('boom'));
+
+    await expect(repairSyncState()).rejects.toThrow(/repair/i);
+  });
+});

--- a/src/tools/__tests__/update-transaction.test.ts
+++ b/src/tools/__tests__/update-transaction.test.ts
@@ -5,6 +5,10 @@ vi.mock('@actual-app/api', () => ({
   getCategories: vi.fn().mockResolvedValue([
     { id: 'cat-1', name: 'Groceries', group_id: 'g1', hidden: false },
   ]),
+  getPayees: vi.fn().mockResolvedValue([
+    { id: 'payee-1', name: 'Supermarket' },
+  ]),
+  createPayee: vi.fn().mockResolvedValue('payee-new'),
   updateTransaction: vi.fn().mockResolvedValue({}),
   sync: vi.fn().mockResolvedValue(undefined),
   runQuery: vi.fn(),
@@ -53,5 +57,58 @@ describe('updateTransactionFields (#25 split sub-transaction amount)', () => {
 
   it('throws when no fields are provided', async () => {
     await expect(updateTransactionFields({ transaction_id: 'x' })).rejects.toThrow(/no fields/i);
+  });
+});
+
+describe('updateTransactionFields (#37 payee must be an id, never payee_name)', () => {
+  beforeEach(() => {
+    vi.mocked(api.updateTransaction).mockClear().mockResolvedValue({} as any);
+    vi.mocked(api.runQuery).mockReset().mockResolvedValue({ data: [{ id: 't-1', amount: -500, is_child: false }] } as any);
+    vi.mocked(api.getPayees).mockClear().mockResolvedValue([
+      { id: 'payee-1', name: 'Supermarket' },
+      // Actual stores transfer payees with an empty name and a transfer_acct.
+      { id: 'transfer-payee-1', name: '', transfer_acct: 'acct-1' },
+    ] as any);
+    vi.mocked(api.createPayee).mockClear().mockResolvedValue('payee-new' as any);
+  });
+
+  it('resolves an existing payee name to its id', async () => {
+    await updateTransactionFields({ transaction_id: 't-1', payee: 'Supermarket' });
+
+    expect(api.updateTransaction).toHaveBeenCalledWith('t-1', { payee: 'payee-1' });
+  });
+
+  it('never sends payee_name, which updateTransaction rejects', async () => {
+    await updateTransactionFields({ transaction_id: 't-1', payee: 'Supermarket' });
+
+    const updates = vi.mocked(api.updateTransaction).mock.calls[0][1] as Record<string, unknown>;
+    expect(updates).not.toHaveProperty('payee_name');
+  });
+
+  it('creates the payee when the name is unknown and uses the new id', async () => {
+    await updateTransactionFields({ transaction_id: 't-1', payee: 'Brand New Shop' });
+
+    expect(api.createPayee).toHaveBeenCalledWith({ name: 'Brand New Shop' });
+    expect(api.updateTransaction).toHaveBeenCalledWith('t-1', { payee: 'payee-new' });
+  });
+
+  // get_transactions output exposes payee ids, so a caller may well pass one
+  // back. Treating it as a name would create a junk payee named with the UUID.
+  it('accepts a payee id as-is instead of creating a payee named after it', async () => {
+    await updateTransactionFields({ transaction_id: 't-1', payee: 'payee-1' });
+
+    expect(api.createPayee).not.toHaveBeenCalled();
+    expect(api.updateTransaction).toHaveBeenCalledWith('t-1', { payee: 'payee-1' });
+  });
+
+  // A blank name used to match Actual's transfer payees (stored with name ''),
+  // silently turning the transaction into a one-sided transfer whose other leg
+  // updateTransaction never creates.
+  it('refuses a blank payee instead of matching a transfer payee', async () => {
+    await expect(
+      updateTransactionFields({ transaction_id: 't-1', payee: '  ' }),
+    ).rejects.toThrow(/payee/i);
+
+    expect(api.updateTransaction).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/analysis/budget-vs-actual.ts
+++ b/src/tools/analysis/budget-vs-actual.ts
@@ -6,6 +6,7 @@ import { formatMoney } from '../../utils/money.js';
 import { resolveMonth } from '../../utils/dates.js';
 import { sectionHeader, formatTable } from '../../utils/formatters.js';
 import type { BudgetMonth, BudgetMonthGroup } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerBudgetVsActual(server: McpServer): void {
   server.tool(
@@ -87,7 +88,7 @@ export function registerBudgetVsActual(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/analysis/category-trends.ts
+++ b/src/tools/analysis/category-trends.ts
@@ -7,6 +7,7 @@ import { resolveMonth, getMonthRange } from '../../utils/dates.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
 import { sectionHeader, formatTable, formatPercent } from '../../utils/formatters.js';
 import type { BudgetMonth, BudgetMonthGroup, BudgetMonthCategory } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerCategoryTrends(server: McpServer): void {
   server.tool(
@@ -36,7 +37,7 @@ export function registerCategoryTrends(server: McpServer): void {
           return await topCategoryTrends(monthRange, monthCount);
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/analysis/monthly-summary.ts
+++ b/src/tools/analysis/monthly-summary.ts
@@ -6,6 +6,7 @@ import { formatMoney, centsToAmount } from '../../utils/money.js';
 import { resolveMonth, getMonthRange } from '../../utils/dates.js';
 import { sectionHeader, formatTable, formatPercent } from '../../utils/formatters.js';
 import type { BudgetMonth, BudgetMonthGroup } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerMonthlySummary(server: McpServer): void {
   server.tool(
@@ -67,7 +68,7 @@ export function registerMonthlySummary(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/analysis/spending-by-category.ts
+++ b/src/tools/analysis/spending-by-category.ts
@@ -5,6 +5,7 @@ import { ensureConnection } from '../../connection.js';
 import { formatMoney, centsToAmount } from '../../utils/money.js';
 import { resolveDate } from '../../utils/dates.js';
 import { sectionHeader, formatTable, formatPercent } from '../../utils/formatters.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerSpendingByCategory(server: McpServer): void {
   server.tool(
@@ -109,7 +110,7 @@ export function registerSpendingByCategory(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/analysis/spending-projection.ts
+++ b/src/tools/analysis/spending-projection.ts
@@ -6,6 +6,7 @@ import { formatMoney } from '../../utils/money.js';
 import { resolveMonth, daysInMonth, daysElapsed } from '../../utils/dates.js';
 import { sectionHeader, formatTable, formatPercent } from '../../utils/formatters.js';
 import type { BudgetMonth, BudgetMonthGroup } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerSpendingProjection(server: McpServer): void {
   server.tool(
@@ -98,7 +99,7 @@ export function registerSpendingProjection(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,6 +29,9 @@ import { registerCreateTransfer } from './write/create-transfer.js';
 import { registerUpdateTransaction } from './write/update-transaction.js';
 import { registerDeleteTransaction } from './write/delete-transaction.js';
 import { registerRunBankSync } from './write/run-bank-sync.js';
+import { registerRepairSync } from './write/repair-sync.js';
+import { registerCreateAccount } from './write/create-account.js';
+import { registerDeleteAccount } from './write/delete-account.js';
 import { registerCreateCategory } from './write/create-category.js';
 import { registerUpdateCategory } from './write/update-category.js';
 import { registerDeleteCategory } from './write/delete-category.js';
@@ -70,6 +73,9 @@ export function registerAllTools(server: McpServer): void {
   registerUpdateTransaction(server);
   registerDeleteTransaction(server);
   registerRunBankSync(server);
+  registerRepairSync(server);
+  registerCreateAccount(server);
+  registerDeleteAccount(server);
 
   // Category CRUD
   registerCreateCategory(server);

--- a/src/tools/read/balance-history.ts
+++ b/src/tools/read/balance-history.ts
@@ -6,6 +6,7 @@ import { formatMoney } from '../../utils/money.js';
 import { resolveAccountId } from '../../utils/resolvers.js';
 import { resolveDate } from '../../utils/dates.js';
 import { sectionHeader, formatTable } from '../../utils/formatters.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerBalanceHistory(server: McpServer): void {
   server.tool(
@@ -108,7 +109,7 @@ export function registerBalanceHistory(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/read/get-budget-month.ts
+++ b/src/tools/read/get-budget-month.ts
@@ -6,6 +6,7 @@ import { formatMoney } from '../../utils/money.js';
 import { resolveMonth } from '../../utils/dates.js';
 import { sectionHeader } from '../../utils/formatters.js';
 import type { BudgetMonth, BudgetMonthGroup } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerGetBudgetMonth(server: McpServer): void {
   server.tool(
@@ -68,7 +69,7 @@ export function registerGetBudgetMonth(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/read/get-budget-summary.ts
+++ b/src/tools/read/get-budget-summary.ts
@@ -6,6 +6,7 @@ import { formatMoney, centsToAmount } from '../../utils/money.js';
 import { resolveMonth } from '../../utils/dates.js';
 import { sectionHeader, formatPercent } from '../../utils/formatters.js';
 import type { BudgetMonth, BudgetMonthGroup } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerGetBudgetSummary(server: McpServer): void {
   server.tool(
@@ -70,7 +71,7 @@ export function registerGetBudgetSummary(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/read/get-categories.ts
+++ b/src/tools/read/get-categories.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { sectionHeader } from '../../utils/formatters.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerGetCategories(server: McpServer): void {
   server.tool(
@@ -52,7 +53,7 @@ export function registerGetCategories(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/read/get-category-balance.ts
+++ b/src/tools/read/get-category-balance.ts
@@ -7,6 +7,7 @@ import { resolveMonth, getMonthRange } from '../../utils/dates.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
 import { sectionHeader, formatTable } from '../../utils/formatters.js';
 import type { BudgetMonth, BudgetMonthGroup, BudgetMonthCategory } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerGetCategoryBalance(server: McpServer): void {
   server.tool(
@@ -86,7 +87,7 @@ export function registerGetCategoryBalance(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/read/get-payees.ts
+++ b/src/tools/read/get-payees.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { sectionHeader } from '../../utils/formatters.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerGetPayees(server: McpServer): void {
   server.tool(
@@ -33,7 +34,7 @@ export function registerGetPayees(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/read/get-rules.ts
+++ b/src/tools/read/get-rules.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { sectionHeader } from '../../utils/formatters.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerGetRules(server: McpServer): void {
   server.tool(
@@ -54,7 +55,7 @@ export function registerGetRules(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/read/get-transactions.ts
+++ b/src/tools/read/get-transactions.ts
@@ -6,6 +6,7 @@ import { formatMoney } from '../../utils/money.js';
 import { resolveDate } from '../../utils/dates.js';
 import { resolveAccountId } from '../../utils/resolvers.js';
 import { sectionHeader, formatTable } from '../../utils/formatters.js';
+import { describeError } from '../../utils/errors.js';
 
 export interface GetTransactionsInput {
   account?: string;
@@ -221,7 +222,7 @@ export function registerGetTransactions(server: McpServer): void {
         const text = await getTransactionsReport(input);
         return { content: [{ type: 'text', text }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/read/list-accounts.ts
+++ b/src/tools/read/list-accounts.ts
@@ -3,6 +3,7 @@ import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { formatMoney } from '../../utils/money.js';
 import { sectionHeader } from '../../utils/formatters.js';
+import { describeError } from '../../utils/errors.js';
 
 // api.getAccountBalance sums only transactions dated on or before the cutoff,
 // defaulting to "today" when no cutoff is given — which silently drops
@@ -62,7 +63,7 @@ export function registerListAccounts(server: McpServer): void {
         const text = await getAccountsReport();
         return { content: [{ type: 'text', text }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/create-account.ts
+++ b/src/tools/write/create-account.ts
@@ -1,0 +1,93 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import * as api from '@actual-app/api';
+import { ensureConnection } from '../../connection.js';
+import { amountToCents, formatMoney } from '../../utils/money.js';
+import { describeError } from '../../utils/errors.js';
+
+export interface CreateAccountInput {
+  name: string;
+  offBudget?: boolean;
+  initialBalance?: number;
+}
+
+/**
+ * Create a new account (#38). Without this, any workflow that needs a new
+ * account — a loan, an investment vehicle, a savings pot — had to stop and be
+ * finished by hand in the Actual UI.
+ *
+ * An `initialBalance` produces Actual's opening "Starting Balance" transaction.
+ *
+ * There is deliberately no `type` option: Actual models accounts as on-budget
+ * or off-budget only (`APIAccountEntity` has no `type` field), so accepting one
+ * would report a change the API silently discards.
+ *
+ * Returns the human-readable confirmation lines, including the new account id
+ * so follow-up calls can target it.
+ */
+export async function createNewAccount(input: CreateAccountInput): Promise<string[]> {
+  if (!input.name || input.name.trim() === '') {
+    throw new Error('Account name is required.');
+  }
+
+  await ensureConnection();
+
+  const offbudget = input.offBudget ?? false;
+  const initialCents = input.initialBalance !== undefined ? amountToCents(input.initialBalance) : 0;
+
+  const accountId = await api.createAccount(
+    {
+      name: input.name.trim(),
+      offbudget,
+    },
+    initialCents,
+  );
+
+  await api.sync();
+
+  const lines = [
+    'Account created:',
+    `  Name:    ${input.name.trim()}`,
+    `  Budget:  ${offbudget ? 'off-budget' : 'on-budget'}`,
+  ];
+  if (initialCents !== 0) lines.push(`  Balance: ${formatMoney(initialCents)}`);
+  lines.push(`  ID:      ${accountId}`);
+
+  return lines;
+}
+
+export function registerCreateAccount(server: McpServer): void {
+  server.tool(
+    'create_account',
+    'Create a new budget account (on-budget or off-budget). Returns the new account ID ' +
+      'so transactions can target it right away.',
+    {
+      name: z.string().describe('Account name'),
+      offBudget: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether the account is off-budget (tracked but outside the budget, e.g. a loan or investment). Defaults to false.',
+        ),
+      initialBalance: z
+        .number()
+        .optional()
+        .describe(
+          'Opening balance in human amounts (e.g. 1500.50, not cents). Creates the "Starting Balance" transaction.',
+        ),
+    },
+    { readOnlyHint: false },
+    async (input) => {
+      try {
+        const lines = await createNewAccount(input);
+        return { content: [{ type: 'text', text: lines.join('\n') }] };
+      } catch (error) {
+        const message = describeError(error);
+        return {
+          content: [{ type: 'text', text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/write/create-category-group.ts
+++ b/src/tools/write/create-category-group.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerCreateCategoryGroup(server: McpServer): void {
   server.tool(
@@ -24,7 +25,7 @@ export function registerCreateCategoryGroup(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/create-category.ts
+++ b/src/tools/write/create-category.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolveCategoryGroupId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerCreateCategory(server: McpServer): void {
   server.tool(
@@ -30,7 +31,7 @@ export function registerCreateCategory(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/create-payee.ts
+++ b/src/tools/write/create-payee.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerCreatePayee(server: McpServer): void {
   server.tool(
@@ -24,7 +25,7 @@ export function registerCreatePayee(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/create-rule.ts
+++ b/src/tools/write/create-rule.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerCreateRule(server: McpServer): void {
   server.tool(
@@ -61,7 +62,7 @@ export function registerCreateRule(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/create-split-transaction.ts
+++ b/src/tools/write/create-split-transaction.ts
@@ -5,6 +5,7 @@ import { ensureConnection } from '../../connection.js';
 import { amountToCents, formatMoney } from '../../utils/money.js';
 import { resolveDate } from '../../utils/dates.js';
 import { resolveAccountId, resolveCategoryId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export interface SplitInput {
   category: string;
@@ -145,7 +146,7 @@ export function registerCreateSplitTransaction(server: McpServer): void {
         const lines = await createSplitTransaction(input);
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/create-transaction.ts
+++ b/src/tools/write/create-transaction.ts
@@ -5,6 +5,7 @@ import { ensureConnection } from '../../connection.js';
 import { amountToCents, formatMoney } from '../../utils/money.js';
 import { resolveDate } from '../../utils/dates.js';
 import { resolveAccountId, resolveCategoryId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export interface CreateTransactionInput {
   account: string;
@@ -166,7 +167,7 @@ export function registerCreateTransaction(server: McpServer): void {
         const lines = await createTransaction(input);
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/create-transfer.ts
+++ b/src/tools/write/create-transfer.ts
@@ -5,6 +5,7 @@ import { ensureConnection } from '../../connection.js';
 import { amountToCents, formatMoney } from '../../utils/money.js';
 import { resolveDate } from '../../utils/dates.js';
 import { resolveAccountId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerCreateTransfer(server: McpServer): void {
   server.tool(
@@ -81,7 +82,7 @@ export function registerCreateTransfer(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/delete-account.ts
+++ b/src/tools/write/delete-account.ts
@@ -1,0 +1,151 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import * as api from '@actual-app/api';
+import { ensureConnection } from '../../connection.js';
+import { resolveAccountId } from '../../utils/resolvers.js';
+import { formatMoney } from '../../utils/money.js';
+import { describeError } from '../../utils/errors.js';
+
+// Same trick as list-accounts: a far-future cutoff yields the full balance
+// instead of only transactions dated up to today (#21).
+const FULL_BALANCE_CUTOFF = new Date('9999-12-31');
+const ALL_TIME_START = '1900-01-01';
+const ALL_TIME_END = '9999-12-31';
+
+export interface DeleteAccountInput {
+  account: string;
+  confirm?: boolean;
+  confirm_name?: string;
+}
+
+export interface DeleteAccountResult {
+  deleted: boolean;
+  lines: string[];
+}
+
+/**
+ * Delete an account, behind deliberate guardrails.
+ *
+ * Deleting an account also destroys its transaction history, and an agent can
+ * reach this tool from a vague instruction, so a single call is never enough:
+ *
+ *  1. The first call *previews* — it reports what would be lost and deletes
+ *     nothing.
+ *  2. `confirm: true` alone is still refused; the caller must also echo the
+ *     account's exact name in `confirm_name` (the pattern GitHub uses for
+ *     repository deletion), which makes a wrong-account deletion take a
+ *     deliberate, verifiable step.
+ *  3. The preview points at closing the account instead, which is Actual's
+ *     non-destructive way to retire an account and keeps its history.
+ */
+export async function deleteAccountGuarded(
+  input: DeleteAccountInput,
+): Promise<DeleteAccountResult> {
+  await ensureConnection();
+
+  const accountId = await resolveAccountId(input.account);
+  const accounts = await api.getAccounts();
+  const account = accounts.find((a) => a.id === accountId);
+  if (!account) {
+    throw new Error(`No account found matching "${input.account}".`);
+  }
+
+  // `api.deleteAccount` early-returns for an already-closed account, so it would
+  // report a deletion that never happened. Worse, it unlinks bank sync *before*
+  // that return, and Actual cannot undo an unlink. Refuse instead.
+  if (account.closed) {
+    throw new Error(
+      `Account "${account.name}" is closed, and Actual cannot delete a closed account. ` +
+        'Reopen it first if you really need it gone; otherwise leave it closed — ' +
+        'closed accounts keep their history and stay out of the way.',
+    );
+  }
+
+  const balance = await api.getAccountBalance(accountId, FULL_BALANCE_CUTOFF);
+  const transactions = await api.getTransactions(accountId, ALL_TIME_START, ALL_TIME_END);
+  const count = transactions.length;
+
+  // Guardrail 2: the exact name must be echoed back.
+  if (input.confirm && input.confirm_name !== undefined && input.confirm_name !== account.name) {
+    throw new Error(
+      `confirm_name "${input.confirm_name}" does not match the account name "${account.name}". ` +
+        'Nothing was deleted.',
+    );
+  }
+
+  // Guardrail 1: preview until both confirmations are present.
+  if (!input.confirm || input.confirm_name === undefined) {
+    const lines = [
+      'Nothing was deleted. Review what this would destroy:',
+      `  Account:      ${account.name}`,
+      `  Balance:      ${formatMoney(balance)}`,
+      `  Transactions: ${count} (deleted along with the account)`,
+      '',
+      'Two side effects Actual cannot undo:',
+      '  - Any bank-sync link on this account is unlinked.',
+      '  - Transfers pointing here lose their payee and transfer link in the',
+      '    other account, leaving orphaned transactions there.',
+      '',
+      // Guardrail 3: offer the reversible option first.
+      'Consider closing the account instead — in Actual, closing retires an',
+      'account while keeping its history, and it can be reopened later.',
+      '',
+      'To really delete it, call again with:',
+      `  confirm: true, confirm_name: "${account.name}"`,
+    ];
+    return { deleted: false, lines };
+  }
+
+  await api.deleteAccount(accountId);
+  await api.sync();
+
+  return {
+    deleted: true,
+    lines: [
+      `Account "${account.name}" deleted.`,
+      `  Balance was:  ${formatMoney(balance)}`,
+      `  Transactions: ${count} removed`,
+    ],
+  };
+}
+
+export function registerDeleteAccount(server: McpServer): void {
+  server.tool(
+    'delete_account',
+    'Delete an account and its entire transaction history. Destructive and irreversible: ' +
+      'the first call only previews what would be lost, and deleting requires both ' +
+      "confirm: true and confirm_name set to the account's exact name. Prefer closing an " +
+      'account when you just want to retire it.',
+    {
+      account: z.string().describe('Account name or ID to delete'),
+      confirm: z
+        .boolean()
+        .optional()
+        .describe('Must be true to delete. Without it, the tool only previews.'),
+      confirm_name: z
+        .string()
+        .optional()
+        .describe(
+          "The account's exact name, echoed back as a safeguard against deleting the wrong account.",
+        ),
+    },
+    { readOnlyHint: false, destructiveHint: true },
+    async (input) => {
+      try {
+        const { deleted, lines } = await deleteAccountGuarded(input);
+        return {
+          content: [{ type: 'text', text: lines.join('\n') }],
+          // Not deleting is reported as an error so the confirmation step is
+          // never mistaken for a completed deletion.
+          ...(deleted ? {} : { isError: true }),
+        };
+      } catch (error) {
+        const message = describeError(error);
+        return {
+          content: [{ type: 'text', text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/write/delete-category-group.ts
+++ b/src/tools/write/delete-category-group.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolveCategoryGroupId, resolveCategoryId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerDeleteCategoryGroup(server: McpServer): void {
   server.tool(
@@ -36,7 +37,7 @@ export function registerDeleteCategoryGroup(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/delete-category.ts
+++ b/src/tools/write/delete-category.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerDeleteCategory(server: McpServer): void {
   server.tool(
@@ -35,7 +36,7 @@ export function registerDeleteCategory(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/delete-payee.ts
+++ b/src/tools/write/delete-payee.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolvePayeeId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerDeletePayee(server: McpServer): void {
   server.tool(
@@ -31,7 +32,7 @@ export function registerDeletePayee(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/delete-rule.ts
+++ b/src/tools/write/delete-rule.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerDeleteRule(server: McpServer): void {
   server.tool(
@@ -23,7 +24,7 @@ export function registerDeleteRule(server: McpServer): void {
           return { content: [{ type: 'text', text: `Rule ${rule_id} not found.` }], isError: true };
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/delete-transaction.ts
+++ b/src/tools/write/delete-transaction.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { formatMoney } from '../../utils/money.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerDeleteTransaction(server: McpServer): void {
   server.tool(
@@ -57,7 +58,7 @@ export function registerDeleteTransaction(server: McpServer): void {
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/recategorize-transaction.ts
+++ b/src/tools/write/recategorize-transaction.ts
@@ -4,6 +4,7 @@ import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { formatMoney } from '../../utils/money.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerRecategorizeTransaction(server: McpServer): void {
   server.tool(
@@ -37,7 +38,7 @@ export function registerRecategorizeTransaction(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/reconcile-currency-residual.ts
+++ b/src/tools/write/reconcile-currency-residual.ts
@@ -5,6 +5,7 @@ import { ensureConnection } from '../../connection.js';
 import { amountToCents, centsToAmount, formatMoney } from '../../utils/money.js';
 import { resolveAccountId } from '../../utils/resolvers.js';
 import { createTransaction } from './create-transaction.js';
+import { describeError } from '../../utils/errors.js';
 
 export interface ReconcileResidualInput {
   account: string;
@@ -88,7 +89,7 @@ export function registerReconcileCurrencyResidual(server: McpServer): void {
         const lines = await reconcileCurrencyResidual(input);
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/repair-sync.ts
+++ b/src/tools/write/repair-sync.ts
@@ -1,0 +1,65 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as api from '@actual-app/api';
+import { ensureConnection, getInternal } from '../../connection.js';
+import { describeError } from '../../utils/errors.js';
+
+/**
+ * Rebuild the local sync state, then sync.
+ *
+ * #41: when a budget goes out-of-sync there was no way out from inside the MCP
+ * server — every tool failed, and the usual remedies do not work: wiping
+ * ACTUAL_DATA_DIR reproduces the same error on the next download (the
+ * inconsistency is in the sync state, not the cache), and restarting the app or
+ * the server changes nothing. Actual's own repair is reachable through the
+ * internal `sync-repair` handler, which is what the UI's "Repair sync" runs.
+ *
+ * Non-destructive: it rebuilds sync bookkeeping, not budget data.
+ *
+ * Returns the human-readable confirmation lines.
+ */
+export async function repairSyncState(): Promise<string[]> {
+  // Deliberately tolerate a failed connection: ensureConnection() runs
+  // downloadBudget(), and an out-of-sync budget is precisely what makes that
+  // throw — bailing out here would make this tool useless in the only
+  // situation it exists for. By then `api.init()` has already returned (so
+  // `send` is available) and the budget itself is loaded; only the sync step
+  // failed. getInternal() throws its own clear error if init never ran.
+  await ensureConnection().catch(() => undefined);
+
+  try {
+    await getInternal().send('sync-repair');
+  } catch (error) {
+    throw new Error(`Sync repair failed: ${describeError(error)}`);
+  }
+
+  await api.sync();
+
+  return [
+    'Sync repair completed.',
+    '  The local sync state was rebuilt and synced with the server.',
+    '  No budget data was modified (only sync bookkeeping).',
+  ];
+}
+
+export function registerRepairSync(server: McpServer): void {
+  server.tool(
+    'repair_sync',
+    "Repair the budget's sync state when operations fail with an out-of-sync error. " +
+      'Rebuilds sync bookkeeping without modifying budget data. Use this when other ' +
+      'tools report that the budget is out of sync.',
+    {},
+    { readOnlyHint: false, idempotentHint: true },
+    async () => {
+      try {
+        const lines = await repairSyncState();
+        return { content: [{ type: 'text', text: lines.join('\n') }] };
+      } catch (error) {
+        const message = describeError(error);
+        return {
+          content: [{ type: 'text', text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/write/run-bank-sync.ts
+++ b/src/tools/write/run-bank-sync.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolveAccountId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerRunBankSync(server: McpServer): void {
   server.tool(
@@ -52,7 +53,7 @@ export function registerRunBankSync(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
 
         if (message.includes('not linked') || message.includes('no bank')) {
           return {

--- a/src/tools/write/update-budget-amount.ts
+++ b/src/tools/write/update-budget-amount.ts
@@ -6,6 +6,7 @@ import { amountToCents, formatMoney } from '../../utils/money.js';
 import { resolveMonth } from '../../utils/dates.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
 import type { BudgetMonth, BudgetMonthGroup, BudgetMonthCategory } from '../../types.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerUpdateBudgetAmount(server: McpServer): void {
   server.tool(
@@ -62,7 +63,7 @@ export function registerUpdateBudgetAmount(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/tools/write/update-category-group.ts
+++ b/src/tools/write/update-category-group.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolveCategoryGroupId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerUpdateCategoryGroup(server: McpServer): void {
   server.tool(
@@ -49,7 +50,7 @@ export function registerUpdateCategoryGroup(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/update-category.ts
+++ b/src/tools/write/update-category.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolveCategoryId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerUpdateCategory(server: McpServer): void {
   server.tool(
@@ -49,7 +50,7 @@ export function registerUpdateCategory(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/update-payee.ts
+++ b/src/tools/write/update-payee.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { resolvePayeeId } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export function registerUpdatePayee(server: McpServer): void {
   server.tool(
@@ -32,7 +33,7 @@ export function registerUpdatePayee(server: McpServer): void {
           }],
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
       }
     },

--- a/src/tools/write/update-transaction.ts
+++ b/src/tools/write/update-transaction.ts
@@ -4,7 +4,8 @@ import * as api from '@actual-app/api';
 import { ensureConnection } from '../../connection.js';
 import { amountToCents, formatMoney } from '../../utils/money.js';
 import { resolveDate } from '../../utils/dates.js';
-import { resolveCategoryId } from '../../utils/resolvers.js';
+import { resolveCategoryId, resolvePayeeName } from '../../utils/resolvers.js';
+import { describeError } from '../../utils/errors.js';
 
 export interface UpdateTransactionInput {
   transaction_id: string;
@@ -39,8 +40,23 @@ export async function updateTransactionFields(input: UpdateTransactionInput): Pr
   }
 
   if (input.payee !== undefined) {
-    updates.payee_name = input.payee;
-    changes.push(`Payee → ${input.payee}`);
+    // #37: updateTransaction only accepts a payee *id*. `payee_name` is an
+    // import-only convenience field, and passing it here makes the SDK throw
+    // ("Field payee_name does not exist on table transactions") outside our
+    // try/catch, which used to take the whole server process down.
+    if (input.payee.trim() === '') {
+      throw new Error(
+        'Payee cannot be blank. Actual has no "no payee" value to set here; ' +
+          'pass a payee name, or leave the payee out to keep the current one.',
+      );
+    }
+    // An id may come straight from get_transactions output; treating it as a
+    // name would create a junk payee named with the UUID.
+    const payees = await api.getPayees();
+    const byId = payees.find((p) => p.id === input.payee);
+    const existing = byId?.id ?? (await resolvePayeeName(input.payee));
+    updates.payee = existing ?? (await api.createPayee({ name: input.payee }));
+    changes.push(`Payee → ${byId?.name || input.payee}`);
   }
 
   if (input.category !== undefined) {
@@ -111,7 +127,7 @@ export function registerUpdateTransaction(server: McpServer): void {
         const lines = await updateTransactionFields(input);
         return { content: [{ type: 'text', text: lines.join('\n') }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeError(error);
         return {
           content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true,

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { describeError } from '../errors.js';
+
+describe('describeError (#40 never surface an empty error)', () => {
+  it('returns the message of an ordinary error', () => {
+    expect(describeError(new Error('Budget not found'))).toBe('Budget not found');
+  });
+
+  it('never returns an empty string when the API throws Error("")', () => {
+    const described = describeError(new Error(''));
+
+    expect(described).not.toBe('');
+    expect(described.length).toBeGreaterThan(0);
+  });
+
+  it('points at the server logs when the error carries no message', () => {
+    expect(describeError(new Error(''))).toMatch(/log|stderr/i);
+  });
+
+  it('explains an out-of-sync failure and how to recover', () => {
+    const described = describeError(new Error('SyncError: out-of-sync'));
+
+    expect(described).toMatch(/sync/i);
+    expect(described).toMatch(/repair/i);
+  });
+
+  it('detects out-of-sync from the reason property of an empty error', () => {
+    const error = Object.assign(new Error(''), { reason: 'out-of-sync' });
+
+    expect(describeError(error)).toMatch(/repair/i);
+  });
+
+  it('stringifies a non-Error value', () => {
+    expect(describeError('plain failure')).toBe('plain failure');
+  });
+
+  // What the SDK really throws for a sync failure is `new Error('')` with no
+  // `reason`: getSyncError() falls through to an i18next instance that is never
+  // initialised, so the message comes out empty. Matching only the literal
+  // "out-of-sync" text left the actionable advice unreachable in practice.
+  it('offers the repair path for the empty error the SDK actually throws', () => {
+    expect(describeError(new Error(''))).toMatch(/repair_sync/);
+  });
+
+  it('tells the user to upgrade, not repair, when the budget needs migrations', () => {
+    const described = describeError(new Error('out-of-sync-migrations'));
+
+    expect(described).toMatch(/version|upgrade|update/i);
+    expect(described).not.toMatch(/repair_sync/);
+  });
+
+  it('names the repair tool when out-of-sync is reported explicitly', () => {
+    expect(describeError(new Error('SyncError: out-of-sync'))).toMatch(/repair_sync/);
+  });
+});

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -52,4 +52,21 @@ describe('describeError (#40 never surface an empty error)', () => {
   it('names the repair tool when out-of-sync is reported explicitly', () => {
     expect(describeError(new Error('SyncError: out-of-sync'))).toMatch(/repair_sync/);
   });
+
+  // String(someObject) is "[object Object]", which hides the failure just as
+  // effectively as an empty message. Actual throws plain objects in places.
+  it('never returns [object Object] for a thrown plain object', () => {
+    const described = describeError({ code: 'EPERM', detail: 'nope' });
+
+    expect(described).not.toContain('[object Object]');
+    expect(described).toContain('EPERM');
+  });
+
+  it('prefers a message property when the thrown value is not an Error', () => {
+    expect(describeError({ message: 'budget is locked' })).toContain('budget is locked');
+  });
+
+  it('still detects out-of-sync inside a thrown plain object', () => {
+    expect(describeError({ reason: 'out-of-sync' })).toMatch(/repair_sync/);
+  });
 });

--- a/src/utils/__tests__/process-guards.integration.test.ts
+++ b/src/utils/__tests__/process-guards.integration.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+
+const run = promisify(execFile);
+
+// The child imports the compiled guard, so this needs a build first.
+const BUILT = existsSync('dist/utils/process-guards.js');
+
+/**
+ * The unit tests exercise an injected fake `process`, which proves the handler
+ * is wired but not the claim that actually matters for #39: that a stray
+ * rejection no longer terminates the process. Only a real child process can
+ * show that, since Node's default mode is what kills it.
+ */
+describe('installProcessGuards in a real process (#39)', () => {
+  const rejectAndKeepGoing = `
+    import { installProcessGuards } from './dist/utils/process-guards.js';
+    installProcessGuards();
+    Promise.reject(new Error('stray rejection'));
+    setTimeout(() => { console.log('SURVIVED'); process.exit(0); }, 50);
+  `;
+
+  it('a process WITHOUT the guard dies on an unhandled rejection', async () => {
+    const withoutGuard = `
+      Promise.reject(new Error('stray rejection'));
+      setTimeout(() => { console.log('SURVIVED'); process.exit(0); }, 50);
+    `;
+
+    await expect(
+      run(process.execPath, ['--input-type=module', '-e', withoutGuard]),
+    ).rejects.toMatchObject({ code: 1 });
+  }, 20000);
+
+  it.skipIf(!BUILT)('a process WITH the guard survives and keeps running', async () => {
+    const { stdout } = await run(process.execPath, [
+      '--input-type=module',
+      '-e',
+      rejectAndKeepGoing,
+    ]);
+
+    expect(stdout).toContain('SURVIVED');
+  }, 20000);
+});

--- a/src/utils/__tests__/process-guards.test.ts
+++ b/src/utils/__tests__/process-guards.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { installProcessGuards } from '../process-guards.js';
+
+/** Minimal stand-in for `process` that records the handlers installed on it. */
+function fakeProcess() {
+  const handlers = new Map<string, (reason: unknown) => void>();
+  return {
+    on(event: string, handler: (reason: unknown) => void) {
+      handlers.set(event, handler);
+      return this;
+    },
+    emit(event: string, reason: unknown) {
+      const handler = handlers.get(event);
+      if (!handler) throw new Error(`no handler for ${event}`);
+      handler(reason);
+    },
+    has(event: string) {
+      return handlers.has(event);
+    },
+  };
+}
+
+describe('installProcessGuards (#39 a library rejection must not kill the server)', () => {
+  it('installs an unhandledRejection handler', () => {
+    const proc = fakeProcess();
+
+    installProcessGuards(proc as any, vi.fn());
+
+    expect(proc.has('unhandledRejection')).toBe(true);
+  });
+
+  it('swallows the rejection instead of rethrowing, so the process survives', () => {
+    const proc = fakeProcess();
+    installProcessGuards(proc as any, vi.fn());
+
+    expect(() => proc.emit('unhandledRejection', new Error('out-of-sync'))).not.toThrow();
+  });
+
+  it('logs the reason so the failure is diagnosable', () => {
+    const proc = fakeProcess();
+    const log = vi.fn();
+    installProcessGuards(proc as any, log);
+
+    proc.emit('unhandledRejection', new Error('SyncError: out-of-sync'));
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(String(log.mock.calls[0][0])).toMatch(/out-of-sync/i);
+  });
+
+  it('still logs something identifiable when the rejection has no message', () => {
+    const proc = fakeProcess();
+    const log = vi.fn();
+    installProcessGuards(proc as any, log);
+
+    proc.emit('unhandledRejection', new Error(''));
+
+    const logged = String(log.mock.calls[0][0]);
+    expect(logged.trim()).not.toBe('');
+    expect(logged).toMatch(/unhandled/i);
+  });
+});

--- a/src/utils/__tests__/resolvers.test.ts
+++ b/src/utils/__tests__/resolvers.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../connection.js', () => ({
 }));
 
 import * as api from '@actual-app/api';
-import { resolveAccountId, resolveCategoryId, resolveCategoryGroupId, resolvePayeeId } from '../resolvers.js';
+import { resolveAccountId, resolveCategoryId, resolveCategoryGroupId, resolvePayeeId, resolvePayeeName } from '../resolvers.js';
 
 describe('resolveAccountId', () => {
   beforeEach(() => {
@@ -209,5 +209,37 @@ describe('resolvePayeeId', () => {
       expect(e.message).toContain('DGII');
       expect(e.message).not.toContain('Transfer');
     }
+  });
+});
+
+describe('resolvePayeeName', () => {
+  beforeEach(() => {
+    vi.mocked(api.getPayees).mockResolvedValue([
+      { id: 'pay-1', name: 'Sirena' },
+      // Actual stores an account's transfer payee with an empty name.
+      { id: 'transfer-1', name: '', transfer_acct: 'acct-1' },
+    ] as any);
+  });
+
+  it('matches a payee by name, case-insensitively', async () => {
+    expect(await resolvePayeeName('sirena')).toBe('pay-1');
+  });
+
+  it('returns undefined for an unknown name', async () => {
+    expect(await resolvePayeeName('Nobody')).toBeUndefined();
+  });
+
+  it('never resolves a blank name to a transfer payee', async () => {
+    // A blank name matching a transfer payee would silently turn a plain
+    // transaction into a one-sided transfer.
+    expect(await resolvePayeeName('')).toBeUndefined();
+  });
+
+  it('ignores transfer payees when matching', async () => {
+    vi.mocked(api.getPayees).mockResolvedValue([
+      { id: 'transfer-2', name: 'Savings', transfer_acct: 'acct-2' },
+    ] as any);
+
+    expect(await resolvePayeeName('Savings')).toBeUndefined();
   });
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -32,10 +32,35 @@ const VERSION_MISMATCH_HELP =
   '@actual-app/api dependency to matching versions. Repairing the sync state will ' +
   'not fix a version mismatch.';
 
+/**
+ * Best-effort readable text for anything that can be thrown.
+ *
+ * `String(value)` on a plain object yields "[object Object]", which hides the
+ * failure as effectively as an empty message — and Actual does throw plain
+ * objects. So prefer an explicit `message`, then fall back to serialising the
+ * object.
+ */
+function readable(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error === null || error === undefined) return '';
+  if (typeof error === 'object') {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim() !== '') return message;
+    try {
+      const json = JSON.stringify(error);
+      // JSON.stringify returns undefined for e.g. a lone function.
+      if (json && json !== '{}') return json;
+    } catch {
+      /* circular or otherwise unserialisable — fall through */
+    }
+    return '';
+  }
+  return String(error);
+}
+
 function haystack(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error ?? '');
   const reason = (error as { reason?: unknown } | null)?.reason;
-  return `${message} ${String(reason ?? '')}`;
+  return `${readable(error)} ${String(reason ?? '')}`;
 }
 
 /**
@@ -50,6 +75,6 @@ export function describeError(error: unknown): string {
   if (/out-of-sync-(migrations|data)/i.test(text)) return VERSION_MISMATCH_HELP;
   if (/out-of-sync/i.test(text)) return OUT_OF_SYNC_HELP;
 
-  const message = error instanceof Error ? error.message : String(error ?? '');
+  const message = readable(error);
   return message.trim() === '' ? EMPTY_ERROR_HINT : message;
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,55 @@
+/**
+ * Error message helpers.
+ *
+ * #40: `@actual-app/api` throws `new Error('')` for some failures — notably a
+ * budget whose sync state is out-of-sync, where `getSyncError()` falls through
+ * to an i18next instance the API bundle never initialises, so the message comes
+ * out empty and no `reason` is attached. Rendering that verbatim produced a bare
+ * "Error:" in the client while the real cause only appeared on stderr, which MCP
+ * users never see. Every tool routes its catch block through here, so a blank
+ * message can never reach the client — and because a blank message from Actual
+ * is in practice a sync/load failure, that is the case the fallback speaks to.
+ */
+
+const REPAIR_HINT =
+  'Run the `repair_sync` tool to rebuild the sync state (non-destructive), or ' +
+  "repair it in the Actual app under Settings > Show advanced settings. Note that " +
+  'deleting the local ACTUAL_DATA_DIR does not help: the inconsistency lives in ' +
+  'the sync state, not in the local cache.';
+
+const EMPTY_ERROR_HINT =
+  'Actual Budget threw an error with no message. This is almost always a sync or ' +
+  `budget-load failure. ${REPAIR_HINT} ` +
+  'The underlying reason is logged on stderr (check the server logs).';
+
+const OUT_OF_SYNC_HELP =
+  "The budget's sync state is out of sync with the Actual server, so no operation " +
+  `can run until it is repaired. ${REPAIR_HINT}`;
+
+const VERSION_MISMATCH_HELP =
+  'This budget cannot be loaded by this version of Actual: its data or migrations ' +
+  'are newer or older than the API supports. Update the Actual app and the ' +
+  '@actual-app/api dependency to matching versions. Repairing the sync state will ' +
+  'not fix a version mismatch.';
+
+function haystack(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const reason = (error as { reason?: unknown } | null)?.reason;
+  return `${message} ${String(reason ?? '')}`;
+}
+
+/**
+ * Turn any thrown value into a message worth showing the user. Never returns
+ * an empty string.
+ */
+export function describeError(error: unknown): string {
+  const text = haystack(error);
+
+  // Checked before plain out-of-sync: these mean "upgrade", not "repair", and
+  // the reasons Actual reports are `out-of-sync-migrations` / `out-of-sync-data`.
+  if (/out-of-sync-(migrations|data)/i.test(text)) return VERSION_MISMATCH_HELP;
+  if (/out-of-sync/i.test(text)) return OUT_OF_SYNC_HELP;
+
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return message.trim() === '' ? EMPTY_ERROR_HINT : message;
+}

--- a/src/utils/process-guards.ts
+++ b/src/utils/process-guards.ts
@@ -1,0 +1,30 @@
+/**
+ * Keep a library-level promise rejection from taking the server down.
+ *
+ * #39: when `@actual-app/api` fails to download/sync the budget it rejects
+ * promises that nothing awaits (e.g. inside its `api/download-budget`
+ * handler). Node defaults to `--unhandled-rejections=throw` (since Node 15), so those
+ * rejections killed the process a few seconds after boot — the client had
+ * already completed the handshake and listed every tool, so the failure looked
+ * like a mysterious "Connection closed", and reconnecting just repeated the
+ * cycle. `src/index.ts` already intends to stay alive after a failed startup
+ * validation so the error can reach the client on the first tool call; this
+ * guard is what makes that intent hold.
+ *
+ * Injectable `proc`/`log` so the behaviour can be tested without a real crash.
+ */
+export function installProcessGuards(
+  proc: NodeJS.Process = process,
+  log: (message: string) => void = console.error,
+): void {
+  proc.on('unhandledRejection', (reason: unknown) => {
+    // Log the raw reason, not the user-facing description: stderr is for
+    // diagnosis, so the original wording (and the stack, when the message is
+    // empty) is what makes the failure traceable.
+    const raw =
+      reason instanceof Error
+        ? reason.message || reason.stack || String(reason)
+        : String(reason);
+    log(`Unhandled rejection (server staying alive): ${raw || '(no message)'}`);
+  });
+}

--- a/src/utils/resolvers.ts
+++ b/src/utils/resolvers.ts
@@ -77,11 +77,22 @@ export async function resolveCategoryId(nameOrId: string): Promise<string> {
   return cats[0].id;
 }
 
+/**
+ * Find a payee id by exact name, or undefined when there is no such payee.
+ *
+ * Transfer payees are excluded: Actual stores them with an empty name and a
+ * `transfer_acct`, so a blank (or account-named) lookup would otherwise return
+ * one and silently turn a plain transaction into a one-sided transfer.
+ */
 export async function resolvePayeeName(name: string): Promise<string | undefined> {
+  const lower = name.trim().toLowerCase();
+  if (lower === '') return undefined;
+
   await ensureConnection();
   const payees = await api.getPayees();
-  const lower = name.toLowerCase();
-  const match = payees.find((p) => p.name.toLowerCase() === lower);
+  const match = payees.find(
+    (p) => !p.transfer_acct && p.name.toLowerCase() === lower,
+  );
   return match?.id;
 }
 


### PR DESCRIPTION
Six issues, all traced back to one bad afternoon: a budget went out of sync and the server became unusable — with no way to see why, and no way to recover from inside the MCP.

Closes #37
Closes #38
Closes #39
Closes #40
Closes #41
Closes #42

## Fixes

**#39 — the server died a few seconds after every start.** `@actual-app/api` rejects promises nothing awaits when a budget download fails, and Node's default throw mode killed the process. The client had already completed the handshake and listed every tool, so it surfaced as a mysterious `Connection closed`, and reconnecting just repeated the cycle. `index.ts` already meant to stay alive after a failed startup validation so the error could reach the client on the first tool call — `installProcessGuards()` is what makes that intent hold, and it is installed before the `--verify` block, which awaits the same call.

An integration test proves the claim with a real child process: without the guard, exit code 1; with it, survival.

**#40 — every tool failed with a bare `Error:`.** The API throws `new Error('')` for sync failures (`getSyncError` falls through to an i18next instance the bundle never initialises), so the only real diagnosis went to stderr, which MCP users never see. `describeError()` now backs all 34 tools plus `index.ts` and `test-connection.ts`. Since a blank message from Actual is in practice a sync failure, that fallback names `repair_sync`. `out-of-sync-migrations` / `-data` are handled separately: those mean *upgrade*, not repair.

**#37 — `update_transaction` with a payee took the process down.** The handler wrote `payee_name`, which `updateTransaction` rejects (`Field payee_name does not exist on table transactions`); the throw escaped the try/catch. Names now resolve to a payee id, creating the payee when it is new. Two related holes closed along the way: a blank name used to match Actual's transfer payees (stored with `name: ''`), silently turning a transaction into a one-sided transfer whose other leg is never created; and a payee **id** passed straight through — which `get_transactions` output invites — used to create a payee named after the UUID.

## New tools

**#41 — `repair_sync`.** Exposes Actual's own `sync-repair` handler, reached through the `send` that `api.init()` returns (`connection.ts` now keeps that value and exposes `getInternal()`). It deliberately tolerates a failed `ensureConnection()`: that call runs `downloadBudget()`, which is exactly what throws on an out-of-sync budget, so bailing out there would leave the tool useless in the only situation it exists for. By then the budget is loaded and only the sync step failed.

Worth stating plainly, because the instinct is wrong: wiping the local `ACTUAL_DATA_DIR` does **not** fix an out-of-sync budget — the inconsistency is in the sync state, not the cache.

**#38 — `create_account`,** returning the new id so transactions can target it immediately. There is deliberately no `type` option: `APIAccountEntity` has no such field (Actual models accounts as on/off-budget only), so accepting one would report a change the API silently discards.

**#42 — `delete_account`, behind guardrails.** Deleting an account destroys its whole transaction history, and an agent can reach the tool from a vague instruction, so one call is never enough:

1. The first call only **previews** — name, balance, transaction count, and the two side effects Actual cannot undo (bank-sync is unlinked; transfers pointing here leave orphans in the other account).
2. Deleting needs `confirm: true` **and** `confirm_name` echoing the account's exact name — the pattern GitHub uses for repository deletion.
3. The preview points at closing the account instead, which keeps history and can be reopened.

Closed accounts are refused outright: `api.deleteAccount` early-returns for them, so it would report a deletion that never happened — while still unlinking bank sync first.

While the tool declines, it returns `isError: true`, so a confirmation prompt is never mistaken for a completed deletion.

## Notes

- `test-connection.ts` routes through `describeError` too: it is what users run when the server is broken, and the failure it most often hits throws an empty error.
- README documents all **37** tools; it claimed 32 and was already two behind (`create_split_transaction`, `reconcile_currency_residual`).
- `*.local.md` is gitignored, for local notes.

## Verification

- **176 tests** (from 140), `tsc` clean.
- Written test-first: each test was watched failing for the right reason before the fix.
- Exercised live against a real budget — including the full `create_account` → guarded `delete_account` cycle, leaving nothing behind.

Two defects were caught by review rather than by tests, and both are worth flagging as cautionary: `repair_sync` originally began with `ensureConnection()`, making it useless in precisely the scenario it was built for (its live test passed only because that budget's sync was already healthy); and `create_account` printed `Type: savings` while the API discarded the field, because a cast had silenced the compiler error that said so.
